### PR TITLE
refactor: aggressive code cleanup (-1,539 lines)

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -132,17 +132,17 @@ impl MetabaseClient {
         params.push("f=all".to_string());
 
         // Add search parameter if provided
-        if let Some(search_term) = search {
-            if !search_term.is_empty() {
-                params.push(format!("q={}", search_term));
-            }
+        if let Some(search_term) = search
+            && !search_term.is_empty()
+        {
+            params.push(format!("q={}", search_term));
         }
 
         // Add collection parameter if provided
-        if let Some(collection_id) = collection {
-            if !collection_id.is_empty() {
-                params.push(format!("collection={}", collection_id));
-            }
+        if let Some(collection_id) = collection
+            && !collection_id.is_empty()
+        {
+            params.push(format!("collection={}", collection_id));
         }
 
         // Build endpoint with parameters
@@ -169,10 +169,10 @@ impl MetabaseClient {
                 .map_err(|e| AppError::Api(convert_json_error(e, &endpoint)))?;
 
             // Apply limit if specified
-            if let Some(limit_value) = limit {
-                if limit_value > 0 {
-                    questions.truncate(limit_value as usize);
-                }
+            if let Some(limit_value) = limit
+                && limit_value > 0
+            {
+                questions.truncate(limit_value as usize);
             }
 
             Ok(questions)
@@ -208,10 +208,10 @@ impl MetabaseClient {
         let mut request = self.build_request(Method::POST, &endpoint);
 
         // Add parameters as JSON body if provided
-        if let Some(params) = parameters {
-            if !params.is_empty() {
-                request = request.json(&params);
-            }
+        if let Some(params) = parameters
+            && !params.is_empty()
+        {
+            request = request.json(&params);
         }
 
         // Send request with extended timeout

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -308,19 +308,19 @@ impl QuestionHandler {
                 let mut processed_result = result;
 
                 // Apply offset if specified
-                if let Some(offset_val) = offset {
-                    if offset_val > 0 {
-                        let offset_manager = OffsetManager::new(Some(offset_val))?;
-                        processed_result = offset_manager.apply_offset(&processed_result)?;
-                        print_verbose(
-                            verbose,
-                            &format!(
-                                "Applied offset: {}, remaining rows: {}",
-                                offset_val,
-                                processed_result.data.rows.len()
-                            ),
-                        );
-                    }
+                if let Some(offset_val) = offset
+                    && offset_val > 0
+                {
+                    let offset_manager = OffsetManager::new(Some(offset_val));
+                    processed_result = offset_manager.apply_offset(&processed_result)?;
+                    print_verbose(
+                        verbose,
+                        &format!(
+                            "Applied offset: {}, remaining rows: {}",
+                            offset_val,
+                            processed_result.data.rows.len()
+                        ),
+                    );
                 }
 
                 // Create table display
@@ -344,7 +344,7 @@ impl QuestionHandler {
                     .total_records(original_row_count)
                     .display_range(display_start, display_end)
                     .offset(offset.unwrap_or(0))
-                    .build()?;
+                    .build();
 
                 print!(
                     "{}",

--- a/src/cli/interactive_display.rs
+++ b/src/cli/interactive_display.rs
@@ -8,11 +8,114 @@ use crossterm::{
     event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
     execute,
     style::{Color, Print, ResetColor, SetForegroundColor},
-    terminal::{self, Clear, ClearType},
+    terminal::{self, Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use std::io::{self, Write};
 
-/// Interactive display manager for full-screen table and pagination
+struct RawModeCleanup;
+impl Drop for RawModeCleanup {
+    fn drop(&mut self) {
+        let _ = terminal::disable_raw_mode();
+    }
+}
+
+struct ScreenCleanup;
+impl Drop for ScreenCleanup {
+    fn drop(&mut self) {
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    }
+}
+
+const CONTROLS_LINE: &str = "Controls: ↑↓/jk=scroll | n/p=page | Home/End | q=quit | h=help";
+
+fn show_standard_help(title: &str) {
+    execute!(
+        io::stdout(),
+        Clear(ClearType::All),
+        cursor::MoveTo(0, 0),
+        SetForegroundColor(Color::Cyan),
+        Print(title),
+        ResetColor,
+        Print("\r\n\r\n"),
+        Print("Page Navigation:\r\n"),
+        Print("  n           : Next page\r\n"),
+        Print("  p           : Previous page\r\n"),
+        Print("  Home        : First page\r\n"),
+        Print("  End         : Last page\r\n"),
+        Print("\r\n"),
+        Print("Scroll Controls (within page):\r\n"),
+        Print("  ↑, k        : Scroll up (1 line)\r\n"),
+        Print("  ↓, j        : Scroll down (1 line)\r\n"),
+        Print("  Page Up     : Scroll up (page)\r\n"),
+        Print("  Page Down   : Scroll down (page)\r\n"),
+        Print("\r\n"),
+        Print("Other Controls:\r\n"),
+        Print("  q, Q, Esc  : Quit\r\n"),
+        Print("  Ctrl+C     : Force quit\r\n"),
+        Print("  h, H       : Show this help\r\n"),
+        Print("\r\n"),
+        SetForegroundColor(Color::Yellow),
+        Print("Press any key to continue..."),
+        ResetColor
+    )
+    .ok();
+    io::stdout().flush().ok();
+    event::read().ok();
+}
+
+enum KeyAction {
+    Quit,
+    ScrollUp,
+    ScrollDown,
+    PageUp,
+    PageDown,
+    NextPage,
+    PrevPage,
+    Home,
+    End,
+    Help,
+    None,
+}
+
+fn parse_key_event(code: KeyCode, modifiers: KeyModifiers) -> KeyAction {
+    match code {
+        KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => KeyAction::Quit,
+        KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => KeyAction::Quit,
+        KeyCode::Up | KeyCode::Char('k') => KeyAction::ScrollUp,
+        KeyCode::Down | KeyCode::Char('j') => KeyAction::ScrollDown,
+        KeyCode::PageUp => KeyAction::PageUp,
+        KeyCode::PageDown => KeyAction::PageDown,
+        KeyCode::Char('n') | KeyCode::Char('N') => KeyAction::NextPage,
+        KeyCode::Char('p') | KeyCode::Char('P') => KeyAction::PrevPage,
+        KeyCode::Home => KeyAction::Home,
+        KeyCode::End => KeyAction::End,
+        KeyCode::Char('h') | KeyCode::Char('H') => KeyAction::Help,
+        _ => KeyAction::None,
+    }
+}
+
+fn display_controls(terminal_height: u16) {
+    execute!(
+        io::stdout(),
+        cursor::MoveTo(0, terminal_height - 2),
+        SetForegroundColor(Color::Green),
+        Print(CONTROLS_LINE),
+        ResetColor
+    )
+    .ok();
+}
+
+fn display_table_lines(lines: &[&str], scroll_offset: usize, available_height: usize) {
+    let total = lines.len();
+    let start = scroll_offset.min(total);
+    let end = (start + available_height).min(total);
+    for i in start..end {
+        if let Some(line) = lines.get(i) {
+            println!("{}\r", line);
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct InteractiveDisplay;
 
@@ -21,8 +124,6 @@ impl InteractiveDisplay {
         Self
     }
 
-    /// Display query results with interactive pagination
-    /// Based on original implementation: RAW mode + Alternate Screen + interactive display with scroll functionality
     pub async fn display_query_result_pagination(
         &self,
         result: &QueryResult,
@@ -32,69 +133,29 @@ impl InteractiveDisplay {
         question_id: u32,
         question_name: &str,
     ) -> Result<(), AppError> {
-        use crossterm::terminal::{
-            EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode, size,
-        };
-        use std::io::{self, Write};
-
-        // RAII cleanup structures
-        struct RawModeCleanup;
-        impl Drop for RawModeCleanup {
-            fn drop(&mut self) {
-                let _ = disable_raw_mode();
-            }
-        }
-
-        struct ScreenCleanup;
-        impl Drop for ScreenCleanup {
-            fn drop(&mut self) {
-                let _ = execute!(io::stdout(), LeaveAlternateScreen);
-            }
-        }
-
         if no_fullscreen {
-            // Simple mode fallback
             let display = crate::display::table::TableDisplay::new();
-            let table_output = display.render_query_result(result)?;
-            println!("{}", table_output);
+            println!("{}", display.render_query_result(result)?);
             return Ok(());
         }
 
-        // Full screen mode - RAW mode + Alternate Screen + scroll
-        match enable_raw_mode() {
+        match terminal::enable_raw_mode() {
             Ok(()) => {
                 let _cleanup = RawModeCleanup;
                 execute!(io::stdout(), EnterAlternateScreen).ok();
                 let _screen_cleanup = ScreenCleanup;
 
-                // Get terminal size
-                let (_terminal_width, terminal_height) = size().unwrap_or((80, 24));
-
-                // Pagination state
+                let (_, terminal_height) = terminal::size().unwrap_or((80, 24));
                 let total_rows = result.data.rows.len();
-                let base_offset = 0; // Use 0 here since the result is already offset-adjusted
-                let available_rows = total_rows.saturating_sub(base_offset);
-                let total_pages = if available_rows == 0 {
-                    1
-                } else {
-                    available_rows.div_ceil(page_size)
-                }; // Total pages considering offset
-                let mut current_page = 1; // Initial display always starts from page 1
-
-                // Table renderer for display
+                let total_pages = total_rows.div_ceil(page_size).max(1);
+                let mut current_page = 1;
+                let mut scroll_offset = 0;
+                let available_height = terminal_height.saturating_sub(8) as usize;
                 let display = crate::display::table::TableDisplay::new();
 
-                // Scroll state (for scrolling within table)
-                let mut scroll_offset = 0;
-                // Reserve 8 lines: header space (5 lines) + prompt space (3 lines)
-                let available_height = terminal_height.saturating_sub(8) as usize;
-
                 loop {
-                    // Get current page data (considering offset)
-                    let start_row = base_offset + (current_page - 1) * page_size;
+                    let start_row = (current_page - 1) * page_size;
                     let end_row = (start_row + page_size).min(total_rows);
-
-                    // Create QueryResult limited to current page data
                     let page_rows = if start_row < total_rows {
                         result.data.rows[start_row..end_row].to_vec()
                     } else {
@@ -108,14 +169,10 @@ impl InteractiveDisplay {
                         },
                     };
 
-                    // Generate table for current page
                     let page_table_output = display.render_query_result(&page_result)?;
                     let table_lines: Vec<&str> = page_table_output.lines().collect();
 
-                    // Clear entire screen
                     execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).ok();
-
-                    // Display header (fixed)
                     execute!(
                         io::stdout(),
                         SetForegroundColor(Color::Cyan),
@@ -124,228 +181,106 @@ impl InteractiveDisplay {
                         Print("\r\n"),
                         SetForegroundColor(Color::Yellow),
                         Print(format!(
-                            "Page {}/{} | Showing rows {}-{} of {} total (available: {}, offset: {}) | Page size: {}",
+                            "Page {}/{} | Rows {}-{} of {} | offset: {} | page_size: {}",
                             current_page,
                             total_pages,
-                            initial_offset.unwrap_or(0) + (current_page - 1) * page_size + 1,  // Correct user display range start
-                            initial_offset.unwrap_or(0) + (current_page - 1) * page_size + (end_row - start_row),  // Correct user display range end
+                            initial_offset.unwrap_or(0) + start_row + 1,
+                            initial_offset.unwrap_or(0) + start_row + (end_row - start_row),
                             total_rows,
-                            available_rows,
                             initial_offset.unwrap_or(0),
                             page_size
                         )),
                         ResetColor,
                         Print("\r\n\r\n")
-                    ).ok();
-
-                    // Display content within scroll range
-                    let total_lines = table_lines.len();
-                    let start_line = scroll_offset.min(total_lines);
-                    let end_line = (start_line + available_height).min(total_lines);
-
-                    if start_line < total_lines {
-                        let display_lines = &table_lines[start_line..end_line];
-                        for line in display_lines {
-                            println!("{}\r", line);
-                        }
-                    }
-
-                    // Clear bottom of screen (prevent leftover characters)
-                    execute!(io::stdout(), Clear(ClearType::FromCursorDown)).ok();
-
-                    // Display prompt (fixed at bottom)
-                    execute!(
-                        io::stdout(),
-                        cursor::MoveTo(0, terminal_height - 2),
-                        SetForegroundColor(Color::Green),
-                        Print("Controls: ↑↓/jk=scroll | n/p=page | Home/End | q=quit | h=help"),
-                        ResetColor
                     )
                     .ok();
 
+                    display_table_lines(&table_lines, scroll_offset, available_height);
+                    execute!(io::stdout(), Clear(ClearType::FromCursorDown)).ok();
+                    display_controls(terminal_height);
                     io::stdout().flush().ok();
 
-                    // Key input processing
                     if let Ok(Event::Key(KeyEvent {
                         code, modifiers, ..
                     })) = event::read()
                     {
-                        match code {
-                            // Exit
-                            KeyCode::Char('q') | KeyCode::Char('Q') => break,
-                            KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
-                                break;
+                        match parse_key_event(code, modifiers) {
+                            KeyAction::Quit => break,
+                            KeyAction::ScrollUp => scroll_offset = scroll_offset.saturating_sub(1),
+                            KeyAction::ScrollDown => {
+                                let max = table_lines.len().saturating_sub(available_height);
+                                scroll_offset = (scroll_offset + 1).min(max);
                             }
-                            KeyCode::Esc => break,
-
-                            // Scroll (line by line)
-                            KeyCode::Up | KeyCode::Char('k') => {
-                                scroll_offset = scroll_offset.saturating_sub(1);
-                            }
-                            KeyCode::Down | KeyCode::Char('j') => {
-                                let max_offset = total_lines.saturating_sub(available_height);
-                                scroll_offset = (scroll_offset + 1).min(max_offset);
-                            }
-
-                            // Page navigation (data pages)
-                            KeyCode::Char('n') => {
-                                if current_page < total_pages {
-                                    current_page += 1;
-                                    scroll_offset = 0; // Reset scroll position for new page
-                                }
-                            }
-                            KeyCode::Char('p') => {
-                                if current_page > 1 {
-                                    current_page -= 1;
-                                    scroll_offset = 0; // Reset scroll position for new page
-                                }
-                            }
-
-                            // Scroll movement (within page)
-                            KeyCode::PageUp => {
+                            KeyAction::PageUp => {
                                 scroll_offset = scroll_offset.saturating_sub(available_height);
                             }
-                            KeyCode::PageDown => {
-                                let max_offset = total_lines.saturating_sub(available_height);
-                                scroll_offset = (scroll_offset + available_height).min(max_offset);
+                            KeyAction::PageDown => {
+                                let max = table_lines.len().saturating_sub(available_height);
+                                scroll_offset = (scroll_offset + available_height).min(max);
                             }
-
-                            // First/last (page navigation)
-                            KeyCode::Home => {
+                            KeyAction::NextPage if current_page < total_pages => {
+                                current_page += 1;
+                                scroll_offset = 0;
+                            }
+                            KeyAction::PrevPage if current_page > 1 => {
+                                current_page -= 1;
+                                scroll_offset = 0;
+                            }
+                            KeyAction::Home => {
                                 current_page = 1;
                                 scroll_offset = 0;
                             }
-                            KeyCode::End => {
-                                current_page = total_pages.max(1);
+                            KeyAction::End => {
+                                current_page = total_pages;
                                 scroll_offset = 0;
                             }
-
-                            // Show help
-                            KeyCode::Char('h') | KeyCode::Char('H') => {
-                                execute!(
-                                    io::stdout(),
-                                    Clear(ClearType::All),
-                                    cursor::MoveTo(0, 0),
-                                    SetForegroundColor(Color::Cyan),
-                                    Print("Keyboard Navigation Help"),
-                                    ResetColor,
-                                    Print("\r\n\r\n"),
-                                    Print("Page Navigation:\r\n"),
-                                    Print("  n           : Next page\r\n"),
-                                    Print("  p           : Previous page\r\n"),
-                                    Print("  Home        : First page\r\n"),
-                                    Print("  End         : Last page\r\n"),
-                                    Print("\r\n"),
-                                    Print("Scroll Controls (within page):\r\n"),
-                                    Print("  ↑, k        : Scroll up (1 line)\r\n"),
-                                    Print("  ↓, j        : Scroll down (1 line)\r\n"),
-                                    Print("  Page Up     : Scroll up (page)\r\n"),
-                                    Print("  Page Down   : Scroll down (page)\r\n"),
-                                    Print("\r\n"),
-                                    Print("Other Controls:\r\n"),
-                                    Print("  q, Q, Esc  : Quit\r\n"),
-                                    Print("  Ctrl+C     : Force quit\r\n"),
-                                    Print("  h, H       : Show this help\r\n"),
-                                    Print("\r\n"),
-                                    SetForegroundColor(Color::Yellow),
-                                    Print("Press any key to continue..."),
-                                    ResetColor
-                                )
-                                .ok();
-                                io::stdout().flush().ok();
-                                event::read().ok();
-                            }
-
-                            _ => {} // Ignore invalid keys
+                            KeyAction::Help => show_standard_help("Keyboard Navigation Help"),
+                            _ => {}
                         }
                     }
                 }
             }
             Err(_) => {
-                // Fallback when RAW mode fails
                 println!("Warning: Could not enable full-screen mode, falling back to simple mode");
                 let display = crate::display::table::TableDisplay::new();
-                let table_output = display.render_query_result(result)?;
-                println!("{}", table_output);
+                println!("{}", display.render_query_result(result)?);
             }
         }
-
         Ok(())
     }
 
-    /// Display question list with interactive pagination
-    /// RAW mode + Alternate Screen + pagination display for Question List
     pub async fn display_question_list_pagination(
         &self,
         questions: &[Question],
         page_size: usize,
     ) -> Result<(), AppError> {
-        use crossterm::terminal::{
-            EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode, size,
-        };
-        use std::io::{self, Write};
-
-        // RAII cleanup structures
-        struct RawModeCleanup;
-        impl Drop for RawModeCleanup {
-            fn drop(&mut self) {
-                let _ = disable_raw_mode();
-            }
-        }
-
-        struct ScreenCleanup;
-        impl Drop for ScreenCleanup {
-            fn drop(&mut self) {
-                let _ = execute!(io::stdout(), LeaveAlternateScreen);
-            }
-        }
-
-        // Full screen mode - RAW mode + Alternate Screen + pagination (always used)
-        match enable_raw_mode() {
+        match terminal::enable_raw_mode() {
             Ok(()) => {
                 let _cleanup = RawModeCleanup;
                 execute!(io::stdout(), EnterAlternateScreen).ok();
                 let _screen_cleanup = ScreenCleanup;
 
-                // Get terminal size
-                let (_terminal_width, terminal_height) = size().unwrap_or((80, 24));
-
-                // Pagination state
-                let total_questions = questions.len();
-                let total_pages = if total_questions == 0 {
-                    1
-                } else {
-                    total_questions.div_ceil(page_size)
-                };
+                let (_, terminal_height) = terminal::size().unwrap_or((80, 24));
+                let total = questions.len();
+                let total_pages = total.div_ceil(page_size).max(1);
                 let mut current_page = 1;
-
-                // Table renderer for display
+                let mut scroll_offset = 0;
+                let available_height = terminal_height.saturating_sub(6) as usize;
                 let display = crate::display::table::TableDisplay::new();
 
-                // Scroll state (for scrolling within table)
-                let mut scroll_offset = 0;
-                // Reserve 6 lines: header space (3 lines) + prompt space (3 lines)
-                let available_height = terminal_height.saturating_sub(6) as usize;
-
                 loop {
-                    // Get current page data
-                    let start_idx = (current_page - 1) * page_size;
-                    let end_idx = (start_idx + page_size).min(total_questions);
-
-                    let page_questions = if start_idx < total_questions {
-                        &questions[start_idx..end_idx]
+                    let start = (current_page - 1) * page_size;
+                    let end = (start + page_size).min(total);
+                    let page_items = if start < total {
+                        &questions[start..end]
                     } else {
                         &[]
                     };
 
-                    // Generate table for current page
-                    let page_table_output = display.render_question_list(page_questions)?;
-                    let table_lines: Vec<&str> = page_table_output.lines().collect();
+                    let table_output = display.render_question_list(page_items)?;
+                    let table_lines: Vec<&str> = table_output.lines().collect();
 
-                    // Clear entire screen
                     execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).ok();
-
-                    // Display header (fixed)
                     execute!(
                         io::stdout(),
                         SetForegroundColor(Color::Cyan),
@@ -354,12 +289,12 @@ impl InteractiveDisplay {
                         Print("\r\n"),
                         SetForegroundColor(Color::Yellow),
                         Print(format!(
-                            "Page {}/{} | Showing questions {}-{} of {} total | Page size: {}",
+                            "Page {}/{} | Showing {}-{} of {} | page_size: {}",
                             current_page,
                             total_pages,
-                            start_idx + 1,
-                            start_idx + page_questions.len(),
-                            total_questions,
+                            start + 1,
+                            start + page_items.len(),
+                            total,
                             page_size
                         )),
                         ResetColor,
@@ -367,264 +302,133 @@ impl InteractiveDisplay {
                     )
                     .ok();
 
-                    // Display content within scroll range
-                    let total_lines = table_lines.len();
-                    let start_line = scroll_offset.min(total_lines);
-                    let end_line = (start_line + available_height).min(total_lines);
-
-                    if start_line < total_lines {
-                        let display_lines = &table_lines[start_line..end_line];
-                        for line in display_lines {
-                            println!("{}\r", line);
-                        }
-                    }
-
-                    // Clear bottom of screen (prevent leftover characters)
+                    display_table_lines(&table_lines, scroll_offset, available_height);
                     execute!(io::stdout(), Clear(ClearType::FromCursorDown)).ok();
-
-                    // Display prompt (fixed at bottom)
-                    execute!(
-                        io::stdout(),
-                        cursor::MoveTo(0, terminal_height - 2),
-                        SetForegroundColor(Color::Green),
-                        Print("Controls: ↑↓/jk=scroll | n/p=page | Home/End | q=quit | h=help"),
-                        ResetColor
-                    )
-                    .ok();
-
+                    display_controls(terminal_height);
                     io::stdout().flush().ok();
 
-                    // Key input processing
                     if let Ok(Event::Key(KeyEvent {
                         code, modifiers, ..
                     })) = event::read()
                     {
-                        match code {
-                            // Exit
-                            KeyCode::Char('q') | KeyCode::Char('Q') => break,
-                            KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
-                                break;
+                        match parse_key_event(code, modifiers) {
+                            KeyAction::Quit => break,
+                            KeyAction::ScrollUp => scroll_offset = scroll_offset.saturating_sub(1),
+                            KeyAction::ScrollDown => {
+                                let max = table_lines.len().saturating_sub(available_height);
+                                scroll_offset = (scroll_offset + 1).min(max);
                             }
-                            KeyCode::Esc => break,
-
-                            // Scroll (line by line)
-                            KeyCode::Up | KeyCode::Char('k') => {
-                                scroll_offset = scroll_offset.saturating_sub(1);
-                            }
-                            KeyCode::Down | KeyCode::Char('j') => {
-                                let max_offset = total_lines.saturating_sub(available_height);
-                                scroll_offset = (scroll_offset + 1).min(max_offset);
-                            }
-
-                            // Page navigation
-                            KeyCode::Char('n') => {
-                                if current_page < total_pages {
-                                    current_page += 1;
-                                    scroll_offset = 0; // Reset scroll position for new page
-                                }
-                            }
-                            KeyCode::Char('p') => {
-                                if current_page > 1 {
-                                    current_page -= 1;
-                                    scroll_offset = 0; // Reset scroll position for new page
-                                }
-                            }
-
-                            // Scroll movement (within page)
-                            KeyCode::PageUp => {
+                            KeyAction::PageUp => {
                                 scroll_offset = scroll_offset.saturating_sub(available_height);
                             }
-                            KeyCode::PageDown => {
-                                let max_offset = total_lines.saturating_sub(available_height);
-                                scroll_offset = (scroll_offset + available_height).min(max_offset);
+                            KeyAction::PageDown => {
+                                let max = table_lines.len().saturating_sub(available_height);
+                                scroll_offset = (scroll_offset + available_height).min(max);
                             }
-
-                            // First/last
-                            KeyCode::Home => {
+                            KeyAction::NextPage if current_page < total_pages => {
+                                current_page += 1;
+                                scroll_offset = 0;
+                            }
+                            KeyAction::PrevPage if current_page > 1 => {
+                                current_page -= 1;
+                                scroll_offset = 0;
+                            }
+                            KeyAction::Home => {
                                 current_page = 1;
                                 scroll_offset = 0;
                             }
-                            KeyCode::End => {
-                                current_page = total_pages.max(1);
+                            KeyAction::End => {
+                                current_page = total_pages;
                                 scroll_offset = 0;
                             }
-
-                            // Show help
-                            KeyCode::Char('h') | KeyCode::Char('H') => {
-                                execute!(
-                                    io::stdout(),
-                                    Clear(ClearType::All),
-                                    cursor::MoveTo(0, 0),
-                                    SetForegroundColor(Color::Cyan),
-                                    Print("Question List - Keyboard Navigation Help"),
-                                    ResetColor,
-                                    Print("\r\n\r\n"),
-                                    Print("Page Navigation:\r\n"),
-                                    Print("  n           : Next page\r\n"),
-                                    Print("  p           : Previous page\r\n"),
-                                    Print("  Home        : First page\r\n"),
-                                    Print("  End         : Last page\r\n"),
-                                    Print("\r\n"),
-                                    Print("Scroll Controls (within page):\r\n"),
-                                    Print("  ↑, k        : Scroll up (1 line)\r\n"),
-                                    Print("  ↓, j        : Scroll down (1 line)\r\n"),
-                                    Print("  Page Up     : Scroll up (page)\r\n"),
-                                    Print("  Page Down   : Scroll down (page)\r\n"),
-                                    Print("\r\n"),
-                                    Print("Other Controls:\r\n"),
-                                    Print("  q, Q, Esc  : Quit\r\n"),
-                                    Print("  Ctrl+C     : Force quit\r\n"),
-                                    Print("  h, H       : Show this help\r\n"),
-                                    Print("\r\n"),
-                                    SetForegroundColor(Color::Yellow),
-                                    Print("Press any key to continue..."),
-                                    ResetColor
-                                )
-                                .ok();
-                                io::stdout().flush().ok();
-                                event::read().ok();
+                            KeyAction::Help => {
+                                show_standard_help("Question List - Keyboard Navigation Help")
                             }
-
-                            _ => {} // Ignore invalid keys
+                            _ => {}
                         }
                     }
                 }
             }
             Err(_) => {
-                // Fallback when RAW mode fails
                 println!("Warning: Could not enable full-screen mode, falling back to simple mode");
                 let display = crate::display::table::TableDisplay::new();
-                let table_output = display.render_question_list(questions)?;
-                println!("{}", table_output);
+                println!("{}", display.render_question_list(questions)?);
             }
         }
-
         Ok(())
     }
 
-    /// Display dashboard list with interactive pagination
-    /// RAW mode + Alternate Screen + pagination display for Dashboard List
     pub async fn display_dashboard_list_pagination(
         &self,
         dashboards: &[Dashboard],
         page_size: usize,
     ) -> Result<(), AppError> {
-        use crossterm::terminal::{
-            EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode, size,
-        };
-        use std::io::{self, Write};
-
-        // RAII cleanup structures
-        struct RawModeCleanup;
-        impl Drop for RawModeCleanup {
-            fn drop(&mut self) {
-                let _ = disable_raw_mode();
-            }
-        }
-
-        struct ScreenCleanup;
-        impl Drop for ScreenCleanup {
-            fn drop(&mut self) {
-                let _ = execute!(io::stdout(), LeaveAlternateScreen);
-            }
-        }
-
-        // Full screen mode - RAW mode + Alternate Screen + scroll
-        match enable_raw_mode() {
+        match terminal::enable_raw_mode() {
             Ok(()) => {
                 let _cleanup = RawModeCleanup;
                 execute!(io::stdout(), EnterAlternateScreen).ok();
                 let _screen_cleanup = ScreenCleanup;
 
-                // Get terminal size
-                let (_terminal_width, terminal_height) = size().unwrap_or((80, 24));
-
-                // Pagination state
-                let total_dashboards = dashboards.len();
-                let total_pages = if total_dashboards == 0 {
-                    1
-                } else {
-                    total_dashboards.div_ceil(page_size)
-                };
+                let (_, terminal_height) = terminal::size().unwrap_or((80, 24));
+                let total = dashboards.len();
+                let total_pages = total.div_ceil(page_size).max(1);
                 let mut current_page = 1;
-
-                // Scroll state (for scrolling within table)
                 let mut scroll_offset = 0;
-                // Reserve 8 lines: header space (5 lines) + prompt space (3 lines)
                 let available_height = terminal_height.saturating_sub(8) as usize;
 
                 loop {
-                    // Get current page data
-                    let start_idx = (current_page - 1) * page_size;
-                    let end_idx = (start_idx + page_size).min(total_dashboards);
-                    let page_dashboards = if start_idx < total_dashboards {
-                        &dashboards[start_idx..end_idx]
+                    let start = (current_page - 1) * page_size;
+                    let end = (start + page_size).min(total);
+                    let page_items = if start < total {
+                        &dashboards[start..end]
                     } else {
                         &[]
                     };
 
-                    // Generate dashboard table lines with text wrapping
                     let mut table_lines = vec![
                         "┌──────┬─────────────────────────────────┬─────────────────────────────────┬──────────────────┬──────────────────┐".to_string(),
                         "│ ID   │ Name                            │ Description                     │ Collection       │ Updated          │".to_string(),
                         "├──────┼─────────────────────────────────┼─────────────────────────────────┼──────────────────┼──────────────────┤".to_string(),
                     ];
 
-                    for dashboard in page_dashboards {
-                        let name_wrapped = wrap_text(&dashboard.name, 31);
-                        let desc_wrapped = dashboard
+                    for d in page_items {
+                        let name_w = wrap_text(&d.name, 31);
+                        let desc_w = d
                             .description
                             .as_ref()
-                            .map(|d| wrap_text(d, 31))
-                            .unwrap_or_else(|| vec!["".to_string()]);
-                        let collection_text = dashboard
-                            .collection_id
-                            .map(|id| format!("ID: {}", id))
-                            .unwrap_or_else(|| "Personal".to_string());
-                        let collection_wrapped = wrap_text(&collection_text, 16);
-                        let updated_wrapped =
-                            wrap_text(&format_datetime(&dashboard.updated_at), 16);
-
-                        // Find maximum lines needed for this row
-                        let max_lines = name_wrapped
+                            .map(|s| wrap_text(s, 31))
+                            .unwrap_or_else(|| vec!["".into()]);
+                        let coll_w = wrap_text(
+                            &d.collection_id
+                                .map(|id| format!("ID: {}", id))
+                                .unwrap_or_else(|| "Personal".into()),
+                            16,
+                        );
+                        let upd_w = wrap_text(&format_datetime(&d.updated_at), 16);
+                        let max_lines = name_w
                             .len()
-                            .max(desc_wrapped.len())
-                            .max(collection_wrapped.len())
-                            .max(updated_wrapped.len());
-
-                        // Generate multi-line row
-                        for line_idx in 0..max_lines {
-                            let empty_string = String::new();
-                            let name_line = name_wrapped.get(line_idx).unwrap_or(&empty_string);
-                            let desc_line = desc_wrapped.get(line_idx).unwrap_or(&empty_string);
-                            let collection_line =
-                                collection_wrapped.get(line_idx).unwrap_or(&empty_string);
-                            let updated_line =
-                                updated_wrapped.get(line_idx).unwrap_or(&empty_string);
-
-                            let id_display = if line_idx == 0 {
-                                dashboard.id.to_string()
-                            } else {
-                                String::new()
-                            };
-
+                            .max(desc_w.len())
+                            .max(coll_w.len())
+                            .max(upd_w.len());
+                        for i in 0..max_lines {
+                            let empty = String::new();
                             table_lines.push(format!(
                                 "│ {:>4} │ {:31} │ {:31} │ {:16} │ {:16} │",
-                                id_display,
-                                pad_to_width(name_line, 31),
-                                pad_to_width(desc_line, 31),
-                                pad_to_width(collection_line, 16),
-                                pad_to_width(updated_line, 16)
+                                if i == 0 {
+                                    d.id.to_string()
+                                } else {
+                                    String::new()
+                                },
+                                pad_to_width(name_w.get(i).unwrap_or(&empty), 31),
+                                pad_to_width(desc_w.get(i).unwrap_or(&empty), 31),
+                                pad_to_width(coll_w.get(i).unwrap_or(&empty), 16),
+                                pad_to_width(upd_w.get(i).unwrap_or(&empty), 16)
                             ));
                         }
                     }
-
                     table_lines.push("└──────┴─────────────────────────────────┴─────────────────────────────────┴──────────────────┴──────────────────┘".to_string());
 
-                    // Clear entire screen
                     execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).ok();
-
-                    // Display header (fixed)
                     execute!(
                         io::stdout(),
                         SetForegroundColor(Color::Cyan),
@@ -633,12 +437,12 @@ impl InteractiveDisplay {
                         Print("\r\n"),
                         SetForegroundColor(Color::Yellow),
                         Print(format!(
-                            "Page {}/{} | Showing dashboards {}-{} of {} total | Page size: {}",
+                            "Page {}/{} | Showing {}-{} of {} | page_size: {}",
                             current_page,
                             total_pages,
-                            start_idx + 1,
-                            end_idx,
-                            total_dashboards,
+                            start + 1,
+                            end,
+                            total,
                             page_size
                         )),
                         ResetColor,
@@ -646,152 +450,64 @@ impl InteractiveDisplay {
                     )
                     .ok();
 
-                    // Display content within scroll range
-                    let total_lines = table_lines.len();
-                    let start_line = scroll_offset.min(total_lines);
-                    let end_line = (start_line + available_height).min(total_lines);
-
-                    if start_line < total_lines {
-                        let display_lines = &table_lines[start_line..end_line];
-                        for line in display_lines {
-                            println!("{}\r", line);
-                        }
-                    }
-
-                    // Clear bottom of screen
+                    let lines_ref: Vec<&str> = table_lines.iter().map(|s| s.as_str()).collect();
+                    display_table_lines(&lines_ref, scroll_offset, available_height);
                     execute!(io::stdout(), Clear(ClearType::FromCursorDown)).ok();
-
-                    // Display prompt (fixed at bottom)
-                    execute!(
-                        io::stdout(),
-                        cursor::MoveTo(0, terminal_height - 2),
-                        SetForegroundColor(Color::Green),
-                        Print("Controls: ↑↓/jk=scroll | n/p=page | Home/End | q=quit | h=help"),
-                        ResetColor
-                    )
-                    .ok();
-
+                    display_controls(terminal_height);
                     io::stdout().flush().ok();
 
-                    // Key input processing
                     if let Ok(Event::Key(KeyEvent {
                         code, modifiers, ..
                     })) = event::read()
                     {
-                        match code {
-                            // Exit
-                            KeyCode::Char('q') | KeyCode::Char('Q') => break,
-                            KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
-                                break;
+                        match parse_key_event(code, modifiers) {
+                            KeyAction::Quit => break,
+                            KeyAction::ScrollUp => scroll_offset = scroll_offset.saturating_sub(1),
+                            KeyAction::ScrollDown => {
+                                let max = table_lines.len().saturating_sub(available_height);
+                                scroll_offset = (scroll_offset + 1).min(max);
                             }
-                            KeyCode::Esc => break,
-
-                            // Scroll (line by line)
-                            KeyCode::Up | KeyCode::Char('k') => {
-                                scroll_offset = scroll_offset.saturating_sub(1);
-                            }
-                            KeyCode::Down | KeyCode::Char('j') => {
-                                let max_offset = total_lines.saturating_sub(available_height);
-                                scroll_offset = (scroll_offset + 1).min(max_offset);
-                            }
-
-                            // Page navigation
-                            KeyCode::Char('n') => {
-                                if current_page < total_pages {
-                                    current_page += 1;
-                                    scroll_offset = 0;
-                                }
-                            }
-                            KeyCode::Char('p') => {
-                                if current_page > 1 {
-                                    current_page -= 1;
-                                    scroll_offset = 0;
-                                }
-                            }
-
-                            // Scroll movement
-                            KeyCode::PageUp => {
+                            KeyAction::PageUp => {
                                 scroll_offset = scroll_offset.saturating_sub(available_height / 2);
                             }
-                            KeyCode::PageDown => {
-                                let max_offset = total_lines.saturating_sub(available_height);
-                                scroll_offset =
-                                    (scroll_offset + available_height / 2).min(max_offset);
+                            KeyAction::PageDown => {
+                                let max = table_lines.len().saturating_sub(available_height);
+                                scroll_offset = (scroll_offset + available_height / 2).min(max);
                             }
-                            KeyCode::Home => {
+                            KeyAction::NextPage if current_page < total_pages => {
+                                current_page += 1;
                                 scroll_offset = 0;
                             }
-                            KeyCode::End => {
-                                scroll_offset = total_lines.saturating_sub(available_height);
+                            KeyAction::PrevPage if current_page > 1 => {
+                                current_page -= 1;
+                                scroll_offset = 0;
                             }
-
-                            // Help
-                            KeyCode::Char('h') => {
-                                self.show_dashboard_help(terminal_height).await?;
+                            KeyAction::Home => scroll_offset = 0,
+                            KeyAction::End => {
+                                scroll_offset = table_lines.len().saturating_sub(available_height);
                             }
-
-                            _ => {} // Ignore other keys
+                            KeyAction::Help => {
+                                show_standard_help("Dashboard List - Keyboard Navigation Help")
+                            }
+                            _ => {}
                         }
                     }
                 }
             }
             Err(_) => {
-                // Fallback when RAW mode fails
                 println!("Warning: Could not enable full-screen mode, falling back to simple mode");
                 println!("Dashboard List ({} found):", dashboards.len());
-                for dashboard in dashboards {
+                for d in dashboards {
                     println!(
                         "  ID: {}, Name: {}, Description: {:?}",
-                        dashboard.id, dashboard.name, dashboard.description
+                        d.id, d.name, d.description
                     );
                 }
             }
         }
-
         Ok(())
     }
 
-    // Helper methods for dashboard display are now imported from utils::text
-
-    async fn show_dashboard_help(&self, _terminal_height: u16) -> Result<(), AppError> {
-        use std::io::{self, Write};
-
-        execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).ok();
-
-        execute!(
-            io::stdout(),
-            SetForegroundColor(Color::Cyan),
-            Print("Dashboard List - Help\r\n\r\n"),
-            ResetColor,
-            Print("Navigation:\r\n"),
-            Print("  ↑/k      - Scroll up one line\r\n"),
-            Print("  ↓/j      - Scroll down one line\r\n"),
-            Print("  Page Up  - Scroll up half page\r\n"),
-            Print("  Page Down- Scroll down half page\r\n"),
-            Print("  Home     - Go to top\r\n"),
-            Print("  End      - Go to bottom\r\n"),
-            Print("  n        - Next page\r\n"),
-            Print("  p        - Previous page\r\n\r\n"),
-            Print("Commands:\r\n"),
-            Print("  q        - Quit\r\n"),
-            Print("  h        - Show this help\r\n\r\n"),
-            SetForegroundColor(Color::Green),
-            Print("Press any key to return to dashboard list..."),
-            ResetColor
-        )
-        .ok();
-
-        io::stdout().flush().ok();
-
-        // Wait for any key press
-        if let Ok(Event::Key(_)) = crossterm::event::read() {
-            // Return to main display
-        }
-
-        Ok(())
-    }
-
-    /// Display dashboard details with interactive features
     pub async fn display_dashboard_details_interactive(
         &self,
         dashboard: &Dashboard,
@@ -800,21 +516,15 @@ impl InteractiveDisplay {
         let table_content = table_display.render_dashboard_details(dashboard)?;
         let table_lines: Vec<String> = table_content.lines().map(|s| s.to_string()).collect();
 
-        // Enable raw mode for keyboard handling
         match terminal::enable_raw_mode() {
             Ok(_) => {
+                let _cleanup = RawModeCleanup;
                 let mut scroll_offset = 0;
                 let (_, terminal_height) = terminal::size().unwrap_or((80, 24));
-                let header_height = 4; // Title + info + blank line
-                let footer_height = 2; // Controls + status
-                let available_height =
-                    (terminal_height as usize).saturating_sub(header_height + footer_height);
+                let available_height = (terminal_height as usize).saturating_sub(6);
 
                 loop {
-                    // Clear screen and reset cursor
                     execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).ok();
-
-                    // Display header
                     execute!(
                         io::stdout(),
                         SetForegroundColor(Color::Cyan),
@@ -831,88 +541,45 @@ impl InteractiveDisplay {
                     )
                     .ok();
 
-                    // Display content within scroll range
-                    let total_lines = table_lines.len();
-                    let start_line = scroll_offset.min(total_lines);
-                    let end_line = (start_line + available_height).min(total_lines);
-
-                    if start_line < total_lines {
-                        let display_lines = &table_lines[start_line..end_line];
-                        for line in display_lines {
+                    let total = table_lines.len();
+                    let start = scroll_offset.min(total);
+                    let end = (start + available_height).min(total);
+                    if start < total {
+                        for line in &table_lines[start..end] {
                             println!("{}\r", line);
                         }
                     }
 
-                    // Clear bottom of screen
                     execute!(io::stdout(), Clear(ClearType::FromCursorDown)).ok();
-
-                    // Display controls at bottom
-                    execute!(
-                        io::stdout(),
-                        cursor::MoveTo(0, terminal_height - 2),
-                        SetForegroundColor(Color::Green),
-                        Print("Controls: ↑↓/jk=scroll | n/p=page | Page Up/Down | Home/End | q=quit | h=help"),
-                        ResetColor
-                    ).ok();
-
+                    display_controls(terminal_height);
                     io::stdout().flush().ok();
 
-                    // Handle keyboard input
                     if let Ok(Event::Key(KeyEvent {
                         code,
                         kind: KeyEventKind::Press,
+                        modifiers,
                         ..
                     })) = event::read()
                     {
-                        match code {
-                            KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => break,
-                            KeyCode::Up | KeyCode::Char('k') => {
-                                scroll_offset = scroll_offset.saturating_sub(1);
+                        match parse_key_event(code, modifiers) {
+                            KeyAction::Quit => break,
+                            KeyAction::ScrollUp => scroll_offset = scroll_offset.saturating_sub(1),
+                            KeyAction::ScrollDown if scroll_offset + available_height < total => {
+                                scroll_offset += 1;
                             }
-                            KeyCode::Down | KeyCode::Char('j') => {
-                                if scroll_offset + available_height < total_lines {
-                                    scroll_offset += 1;
-                                }
-                            }
-                            KeyCode::PageUp => {
+                            KeyAction::PageUp => {
                                 scroll_offset = scroll_offset.saturating_sub(available_height);
                             }
-                            KeyCode::PageDown => {
+                            KeyAction::PageDown => {
                                 scroll_offset = (scroll_offset + available_height)
-                                    .min(total_lines.saturating_sub(available_height));
+                                    .min(total.saturating_sub(available_height));
                             }
-                            KeyCode::Home => scroll_offset = 0,
-                            KeyCode::End => {
-                                scroll_offset = total_lines.saturating_sub(available_height);
+                            KeyAction::Home => scroll_offset = 0,
+                            KeyAction::End => {
+                                scroll_offset = total.saturating_sub(available_height)
                             }
-                            KeyCode::Char('h') | KeyCode::Char('H') => {
-                                execute!(
-                                    io::stdout(),
-                                    Clear(ClearType::All),
-                                    cursor::MoveTo(0, 0),
-                                    SetForegroundColor(Color::Cyan),
-                                    Print("Dashboard Details - Keyboard Navigation Help"),
-                                    ResetColor,
-                                    Print("\r\n\r\n"),
-                                    Print("Scroll Controls:\r\n"),
-                                    Print("  ↑, k        : Scroll up (1 line)\r\n"),
-                                    Print("  ↓, j        : Scroll down (1 line)\r\n"),
-                                    Print("  Page Up     : Scroll up (page)\r\n"),
-                                    Print("  Page Down   : Scroll down (page)\r\n"),
-                                    Print("  Home        : Top\r\n"),
-                                    Print("  End         : Bottom\r\n"),
-                                    Print("\r\n"),
-                                    Print("Other Controls:\r\n"),
-                                    Print("  q, Q, Esc  : Quit\r\n"),
-                                    Print("  h, H       : Show this help\r\n"),
-                                    Print("\r\n"),
-                                    SetForegroundColor(Color::Yellow),
-                                    Print("Press any key to continue..."),
-                                    ResetColor
-                                )
-                                .ok();
-                                io::stdout().flush().ok();
-                                event::read().ok();
+                            KeyAction::Help => {
+                                show_standard_help("Dashboard Details - Keyboard Navigation Help")
                             }
                             _ => {}
                         }
@@ -920,55 +587,41 @@ impl InteractiveDisplay {
                 }
             }
             Err(_) => {
-                // Fallback to simple display
                 println!("Warning: Could not enable full-screen mode, falling back to simple mode");
-                let table_display = crate::display::table::TableDisplay::new();
-                let table_content = table_display.render_dashboard_details(dashboard)?;
                 println!("{}", table_content);
             }
         }
-
         Ok(())
     }
 
-    /// Display dashboard cards with interactive features and pagination
     pub async fn display_dashboard_cards_interactive(
         &self,
         cards: &[DashboardCard],
         dashboard_id: u32,
         page_size: usize,
     ) -> Result<(), AppError> {
-        // Implement pagination similar to dashboard_list_pagination
-        let total_cards = cards.len();
-        let total_pages = total_cards.div_ceil(page_size); // Ceiling division
+        let total = cards.len();
+        let total_pages = total.div_ceil(page_size).max(1);
         let mut current_page = 1;
 
-        // Enable raw mode for keyboard handling
         match terminal::enable_raw_mode() {
             Ok(_) => {
+                let _cleanup = RawModeCleanup;
                 let mut scroll_offset = 0;
                 let (_, terminal_height) = terminal::size().unwrap_or((80, 24));
-                let header_height = 4; // Title + info + blank line
-                let footer_height = 2; // Controls + status
-                let available_height =
-                    (terminal_height as usize).saturating_sub(header_height + footer_height);
+                let available_height = (terminal_height as usize).saturating_sub(6);
 
                 loop {
-                    // Calculate current page data
-                    let start_idx = (current_page - 1) * page_size;
-                    let end_idx = (start_idx + page_size).min(total_cards);
-                    let current_cards = &cards[start_idx..end_idx];
+                    let start = (current_page - 1) * page_size;
+                    let end = (start + page_size).min(total);
+                    let current_cards = cards.get(start..end).unwrap_or(&[]);
 
-                    // Generate table for current page
                     let table_display = crate::display::table::TableDisplay::new();
                     let table_content = table_display.render_dashboard_cards(current_cards)?;
                     let table_lines: Vec<String> =
                         table_content.lines().map(|s| s.to_string()).collect();
 
-                    // Clear entire screen
                     execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).ok();
-
-                    // Display header (fixed)
                     execute!(
                         io::stdout(),
                         SetForegroundColor(Color::Cyan),
@@ -977,12 +630,12 @@ impl InteractiveDisplay {
                         Print("\r\n"),
                         SetForegroundColor(Color::Yellow),
                         Print(format!(
-                            "Page {}/{} | Showing cards {}-{} of {} total | Page size: {}",
+                            "Page {}/{} | Showing {}-{} of {} | page_size: {}",
                             current_page,
                             total_pages,
-                            start_idx + 1,
-                            end_idx,
-                            total_cards,
+                            start + 1,
+                            end,
+                            total,
                             page_size
                         )),
                         ResetColor,
@@ -990,105 +643,59 @@ impl InteractiveDisplay {
                     )
                     .ok();
 
-                    // Display content within scroll range
                     let total_lines = table_lines.len();
                     let start_line = scroll_offset.min(total_lines);
                     let end_line = (start_line + available_height).min(total_lines);
-
                     if start_line < total_lines {
-                        let display_lines = &table_lines[start_line..end_line];
-                        for line in display_lines {
+                        for line in &table_lines[start_line..end_line] {
                             println!("{}\r", line);
                         }
                     }
 
-                    // Clear bottom of screen
                     execute!(io::stdout(), Clear(ClearType::FromCursorDown)).ok();
-
-                    // Display controls at bottom
-                    execute!(
-                        io::stdout(),
-                        cursor::MoveTo(0, terminal_height - 2),
-                        SetForegroundColor(Color::Green),
-                        Print("Controls: ↑↓/jk=scroll | n/p=page | Page Up/Down | Home/End | q=quit | h=help"),
-                        ResetColor
-                    ).ok();
-
+                    display_controls(terminal_height);
                     io::stdout().flush().ok();
 
-                    // Handle keyboard input
                     if let Ok(Event::Key(KeyEvent {
                         code,
                         kind: KeyEventKind::Press,
+                        modifiers,
                         ..
                     })) = event::read()
                     {
-                        match code {
-                            KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => break,
-                            KeyCode::Up | KeyCode::Char('k') => {
-                                scroll_offset = scroll_offset.saturating_sub(1);
+                        match parse_key_event(code, modifiers) {
+                            KeyAction::Quit => break,
+                            KeyAction::ScrollUp => scroll_offset = scroll_offset.saturating_sub(1),
+                            KeyAction::ScrollDown
+                                if scroll_offset + available_height < total_lines =>
+                            {
+                                scroll_offset += 1;
                             }
-                            KeyCode::Down | KeyCode::Char('j') => {
-                                if scroll_offset + available_height < total_lines {
-                                    scroll_offset += 1;
-                                }
-                            }
-                            KeyCode::PageUp => {
+                            KeyAction::PageUp => {
                                 scroll_offset = scroll_offset.saturating_sub(available_height);
                             }
-                            KeyCode::PageDown => {
+                            KeyAction::PageDown => {
                                 scroll_offset = (scroll_offset + available_height)
                                     .min(total_lines.saturating_sub(available_height));
                             }
-                            KeyCode::Home => {
+                            KeyAction::NextPage if current_page < total_pages => {
+                                current_page += 1;
+                                scroll_offset = 0;
+                            }
+                            KeyAction::PrevPage if current_page > 1 => {
+                                current_page -= 1;
+                                scroll_offset = 0;
+                            }
+                            KeyAction::Home => {
                                 current_page = 1;
                                 scroll_offset = 0;
                             }
-                            KeyCode::End => {
-                                current_page = total_pages.max(1);
+                            KeyAction::End => {
+                                current_page = total_pages;
                                 scroll_offset = 0;
                             }
-                            // Page navigation
-                            KeyCode::Char('n') | KeyCode::Char('N') => {
-                                if current_page < total_pages {
-                                    current_page += 1;
-                                    scroll_offset = 0;
-                                }
-                            }
-                            KeyCode::Char('p') | KeyCode::Char('P') => {
-                                if current_page > 1 {
-                                    current_page -= 1;
-                                    scroll_offset = 0;
-                                }
-                            }
-                            KeyCode::Char('h') | KeyCode::Char('H') => {
-                                execute!(
-                                    io::stdout(),
-                                    Clear(ClearType::All),
-                                    cursor::MoveTo(0, 0),
-                                    SetForegroundColor(Color::Cyan),
-                                    Print("Dashboard Cards - Keyboard Navigation Help"),
-                                    ResetColor,
-                                    Print("\r\n\r\n"),
-                                    Print("Scroll Controls:\r\n"),
-                                    Print("  ↑, k        : Scroll up (1 line)\r\n"),
-                                    Print("  ↓, j        : Scroll down (1 line)\r\n"),
-                                    Print("  Page Up     : Scroll up (page)\r\n"),
-                                    Print("  Page Down   : Scroll down (page)\r\n"),
-                                    Print("  Home        : Top\r\n"),
-                                    Print("  End         : Bottom\r\n"),
-                                    Print("\r\n"),
-                                    Print("Other Controls:\r\n"),
-                                    Print("  q, Q, Esc  : Quit\r\n"),
-                                    Print("  h, H       : Show this help\r\n"),
-                                    Print("\r\n"),
-                                    SetForegroundColor(Color::Yellow),
-                                    Print("Press any key to continue..."),
-                                    ResetColor
-                                )
-                                .ok();
-                                io::stdout().flush().ok();
-                                event::read().ok();
+                            KeyAction::Help => {
+                                show_standard_help("Dashboard Cards - Keyboard Navigation Help")
                             }
                             _ => {}
                         }
@@ -1096,73 +703,85 @@ impl InteractiveDisplay {
                 }
             }
             Err(_) => {
-                // Fallback to simple display
                 println!("Warning: Could not enable full-screen mode, falling back to simple mode");
                 let table_display = crate::display::table::TableDisplay::new();
-                let table_content = table_display.render_dashboard_cards(cards)?;
-                println!("{}", table_content);
+                println!("{}", table_display.render_dashboard_cards(cards)?);
             }
         }
-
         Ok(())
     }
 
-    /// Display collection list in fullscreen mode with proper terminal handling  
-    /// This replaces the old display_collection_list_pagination with a stable implementation
     pub async fn display_collection_list_fullscreen(
         &self,
         collections: &[Collection],
         page_size: usize,
     ) -> Result<(), AppError> {
-        use crossterm::terminal::{
-            EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode, size,
-        };
-        use std::io::{self, Write};
-
-        // RAII cleanup structures
-        struct RawModeCleanup;
-        impl Drop for RawModeCleanup {
-            fn drop(&mut self) {
-                let _ = disable_raw_mode();
-            }
-        }
-
-        struct ScreenCleanup;
-        impl Drop for ScreenCleanup {
-            fn drop(&mut self) {
-                let _ = execute!(io::stdout(), LeaveAlternateScreen);
-            }
-        }
-
-        // Full screen mode - RAW mode + Alternate Screen + pagination
-        match enable_raw_mode() {
+        match terminal::enable_raw_mode() {
             Ok(()) => {
                 let _cleanup = RawModeCleanup;
                 execute!(io::stdout(), EnterAlternateScreen).ok();
                 let _screen_cleanup = ScreenCleanup;
 
-                // Get terminal size for dynamic layout
-                let (terminal_width, terminal_height) = size().unwrap_or((80, 24));
-
-                // Pagination state
-                let total_collections = collections.len();
-                let total_pages = if total_collections == 0 {
-                    1
-                } else {
-                    total_collections.div_ceil(page_size)
-                };
+                let (terminal_width, terminal_height) = terminal::size().unwrap_or((80, 24));
+                let total = collections.len();
+                let total_pages = total.div_ceil(page_size).max(1);
                 let mut current_page = 1;
-
-                // Scroll state (for scrolling within table)
                 let mut scroll_offset = 0;
-                // Reserve 6 lines: header space (3 lines) + prompt space (3 lines)
                 let available_height = terminal_height.saturating_sub(6) as usize;
 
-                loop {
-                    // Clear screen and reset cursor
-                    execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).ok();
+                let available_width = (terminal_width as usize).saturating_sub(7);
+                let id_w = (available_width * 8 / 100).clamp(4, 8);
+                let name_w = (available_width * 35 / 100).clamp(10, 25);
+                let desc_w = (available_width * 45 / 100).clamp(15, 35);
+                let type_w = available_width.saturating_sub(id_w + name_w + desc_w);
 
-                    // Header with colored title
+                let top = format!(
+                    "┌{:─<id$}┬{:─<name$}┬{:─<desc$}┬{:─<t$}┐",
+                    "",
+                    "",
+                    "",
+                    "",
+                    id = id_w,
+                    name = name_w,
+                    desc = desc_w,
+                    t = type_w
+                );
+                let header = format!(
+                    "│{:^id$}│{:^name$}│{:^desc$}│{:^t$}│",
+                    "ID",
+                    "Name",
+                    "Description",
+                    "Type",
+                    id = id_w,
+                    name = name_w,
+                    desc = desc_w,
+                    t = type_w
+                );
+                let sep = format!(
+                    "├{:─<id$}┼{:─<name$}┼{:─<desc$}┼{:─<t$}┤",
+                    "",
+                    "",
+                    "",
+                    "",
+                    id = id_w,
+                    name = name_w,
+                    desc = desc_w,
+                    t = type_w
+                );
+                let bottom = format!(
+                    "└{:─<id$}┴{:─<name$}┴{:─<desc$}┴{:─<t$}┘",
+                    "",
+                    "",
+                    "",
+                    "",
+                    id = id_w,
+                    name = name_w,
+                    desc = desc_w,
+                    t = type_w
+                );
+
+                loop {
+                    execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).ok();
                     execute!(
                         io::stdout(),
                         SetForegroundColor(Color::Cyan),
@@ -1171,251 +790,145 @@ impl InteractiveDisplay {
                         Print("\r\n"),
                         SetForegroundColor(Color::Yellow),
                         Print(format!(
-                            "Total: {} collections | Page {} of {} | Showing {} items per page",
-                            total_collections, current_page, total_pages, page_size
+                            "Total: {} | Page {} of {} | page_size: {}",
+                            total, current_page, total_pages, page_size
                         )),
                         ResetColor,
-                        Print("\r\n\r\n")
-                    )
-                    .ok();
-
-                    // Calculate appropriate column widths based on terminal size
-                    let total_width = terminal_width as usize;
-                    let available_width = total_width.saturating_sub(7); // Border chars
-
-                    // Distribute width: 8% ID, 35% Name, 45% Description, 12% Type
-                    let id_width = (available_width * 8 / 100).clamp(4, 8);
-                    let name_width = (available_width * 35 / 100).clamp(10, 25);
-                    let desc_width = (available_width * 45 / 100).clamp(15, 35);
-                    let type_width =
-                        available_width.saturating_sub(id_width + name_width + desc_width);
-
-                    // Dynamic table header
-                    let top_border = format!("┌{:─<id$}┬{:─<name$}┬{:─<desc$}┬{:─<type$}┐", "", "", "", "", 
-                                            id = id_width, name = name_width, desc = desc_width, type = type_width);
-                    let header_row = format!("│{:^id$}│{:^name$}│{:^desc$}│{:^type$}│", 
-                                            "ID", "Name", "Description", "Type",
-                                            id = id_width, name = name_width, desc = desc_width, type = type_width);
-                    let separator = format!("├{:─<id$}┼{:─<name$}┼{:─<desc$}┼{:─<type$}┤", "", "", "", "",
-                                          id = id_width, name = name_width, desc = desc_width, type = type_width);
-
-                    execute!(
-                        io::stdout(),
-                        Print(&top_border),
+                        Print("\r\n\r\n"),
+                        Print(&top),
                         Print("\r\n"),
-                        Print(&header_row),
+                        Print(&header),
                         Print("\r\n"),
-                        Print(&separator),
+                        Print(&sep),
                         Print("\r\n")
                     )
                     .ok();
 
-                    // Get current page data
-                    let start_idx = (current_page - 1) * page_size;
-                    let end_idx = (start_idx + page_size).min(total_collections);
-                    let page_collections = if start_idx < total_collections {
-                        &collections[start_idx..end_idx]
+                    let start = (current_page - 1) * page_size;
+                    let end = (start + page_size).min(total);
+                    let page_items = if start < total {
+                        &collections[start..end]
                     } else {
                         &[]
                     };
 
-                    // Display collection rows
-                    let table_lines: Vec<String> = page_collections.iter().map(|collection| {
-                        let id_str = collection.id.map_or("root".to_string(), |id| id.to_string());
-                        let name = truncate_text(&collection.name, name_width);
-                        let description = truncate_text("", desc_width); // Collections don't have descriptions
-                        let collection_type = if collection.id.is_none() { "Root" } else { "Collection" };
-                        format!("│{:id$}│{:name$}│{:desc$}│{:type$}│", 
-                                id_str, name, description, collection_type,
-                                id = id_width, name = name_width, desc = desc_width, type = type_width)
-                    }).collect();
+                    let table_lines: Vec<String> = page_items
+                        .iter()
+                        .map(|c| {
+                            let id_str = c.id.map_or("root".into(), |id| id.to_string());
+                            let ctype = if c.id.is_none() { "Root" } else { "Collection" };
+                            format!(
+                                "│{:id$}│{:name$}│{:desc$}│{:t$}│",
+                                id_str,
+                                truncate_text(&c.name, name_w),
+                                truncate_text("", desc_w),
+                                ctype,
+                                id = id_w,
+                                name = name_w,
+                                desc = desc_w,
+                                t = type_w
+                            )
+                        })
+                        .collect();
 
-                    // Display table lines with scrolling
-                    let total_lines = table_lines.len();
-                    let start_line = scroll_offset.min(total_lines);
-                    let end_line = (start_line + available_height).min(total_lines);
-
-                    if start_line < total_lines {
-                        let display_lines = &table_lines[start_line..end_line];
-                        for line in display_lines {
+                    let lines_len = table_lines.len();
+                    let start_line = scroll_offset.min(lines_len);
+                    let end_line = (start_line + available_height).min(lines_len);
+                    if start_line < lines_len {
+                        for line in &table_lines[start_line..end_line] {
                             execute!(io::stdout(), Print(line), Print("\r\n")).ok();
                         }
                     }
 
-                    // Table bottom border
-                    let bottom_border = format!("└{:─<id$}┴{:─<name$}┴{:─<desc$}┴{:─<type$}┘", "", "", "", "",
-                                               id = id_width, name = name_width, desc = desc_width, type = type_width);
-                    execute!(io::stdout(), Print(&bottom_border), Print("\r\n\r\n")).ok();
-
-                    // Control instructions
+                    execute!(io::stdout(), Print(&bottom), Print("\r\n\r\n")).ok();
                     execute!(
                         io::stdout(),
                         SetForegroundColor(Color::Green),
-                        Print("Controls: [q]uit | [n]ext page | [p]revious page | [h]elp"),
+                        Print("Controls: [q]uit | [n]ext | [p]rev | [h]elp"),
                         ResetColor
                     )
                     .ok();
-
                     io::stdout().flush().ok();
 
-                    // Handle input
-                    if let Event::Key(KeyEvent { code, kind, .. }) =
-                        event::read().unwrap_or(Event::Key(KeyEvent::from(KeyCode::Char('q'))))
+                    if let Ok(Event::Key(KeyEvent {
+                        code,
+                        kind: KeyEventKind::Press,
+                        modifiers,
+                        ..
+                    })) = event::read()
                     {
-                        if kind == KeyEventKind::Press {
-                            match code {
-                                KeyCode::Char('q') | KeyCode::Esc => break,
-                                KeyCode::Char('n') | KeyCode::Right => {
-                                    if current_page < total_pages {
-                                        current_page += 1;
-                                        scroll_offset = 0;
-                                    }
-                                }
-                                KeyCode::Char('p') | KeyCode::Left => {
-                                    if current_page > 1 {
-                                        current_page -= 1;
-                                        scroll_offset = 0;
-                                    }
-                                }
-                                KeyCode::Char('j') | KeyCode::Down => {
-                                    if start_line + available_height < total_lines {
-                                        scroll_offset += 1;
-                                    }
-                                }
-                                KeyCode::Char('k') | KeyCode::Up => {
-                                    scroll_offset = scroll_offset.saturating_sub(1);
-                                }
-                                KeyCode::Home => {
-                                    current_page = 1;
-                                    scroll_offset = 0;
-                                }
-                                KeyCode::End => {
-                                    current_page = total_pages;
-                                    scroll_offset = 0;
-                                }
-                                KeyCode::Char('h') => {
-                                    self.show_collection_list_help().await?;
-                                }
-                                _ => {} // Ignore other keys
+                        match parse_key_event(code, modifiers) {
+                            KeyAction::Quit => break,
+                            KeyAction::NextPage if current_page < total_pages => {
+                                current_page += 1;
+                                scroll_offset = 0;
                             }
+                            KeyAction::PrevPage if current_page > 1 => {
+                                current_page -= 1;
+                                scroll_offset = 0;
+                            }
+                            KeyAction::ScrollDown if start_line + available_height < lines_len => {
+                                scroll_offset += 1;
+                            }
+                            KeyAction::ScrollUp => scroll_offset = scroll_offset.saturating_sub(1),
+                            KeyAction::Home => {
+                                current_page = 1;
+                                scroll_offset = 0;
+                            }
+                            KeyAction::End => {
+                                current_page = total_pages;
+                                scroll_offset = 0;
+                            }
+                            KeyAction::Help => {
+                                self.show_simple_help(
+                                    "Collection List - Help",
+                                    "This screen shows all collections.",
+                                )
+                                .await?
+                            }
+                            _ => {}
                         }
                     }
                 }
             }
             Err(_) => {
-                // Fallback: Simple output if RAW mode fails
                 println!("Collection List ({} collections):", collections.len());
-                for (i, collection) in collections.iter().enumerate() {
-                    let id_str = collection
-                        .id
-                        .map_or("root".to_string(), |id| id.to_string());
-                    let collection_type = if collection.id.is_none() {
-                        "Root"
-                    } else {
-                        "Collection"
-                    };
+                for (i, c) in collections.iter().enumerate() {
+                    let id_str = c.id.map_or("root".into(), |id| id.to_string());
+                    let ctype = if c.id.is_none() { "Root" } else { "Collection" };
                     println!(
                         "{:3}. ID: {:8} | Name: {:25} | Type: {}",
                         i + 1,
                         id_str,
-                        truncate_text(&collection.name, 25),
-                        collection_type
+                        truncate_text(&c.name, 25),
+                        ctype
                     );
                 }
             }
         }
-
         Ok(())
     }
 
-    /// Help display for collection list
-    async fn show_collection_list_help(&self) -> Result<(), AppError> {
-        execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).ok();
-
-        execute!(
-            io::stdout(),
-            SetForegroundColor(Color::Cyan),
-            Print("Collection List - Help"),
-            ResetColor,
-            Print("\r\n\r\n"),
-            Print("Available Commands:\r\n"),
-            Print("  q - Quit and return to previous screen\r\n"),
-            Print("  n - Next page\r\n"),
-            Print("  p - Previous page\r\n"),
-            Print("  j/↓ - Scroll down within current page\r\n"),
-            Print("  k/↑ - Scroll up within current page\r\n"),
-            Print("  Home - Go to first page\r\n"),
-            Print("  End - Go to last page\r\n"),
-            Print("  h - Show this help\r\n"),
-            Print("  ESC - Same as 'q'\r\n"),
-            Print("\r\n"),
-            Print("This screen shows all collections in your Metabase instance.\r\n"),
-            Print("Collections are used to organize questions and dashboards.\r\n"),
-            Print("The root collection contains items not placed in other collections.\r\n"),
-            Print("\r\n"),
-            SetForegroundColor(Color::Yellow),
-            Print("Press any key to return..."),
-            ResetColor
-        )
-        .ok();
-
-        io::stdout().flush().ok();
-        event::read().ok(); // Wait for any key press
-
-        Ok(())
-    }
-
-    /// Display collection details in fullscreen mode with proper terminal handling
-    /// This replaces the old display_collection_details_interactive with a stable implementation
     pub async fn display_collection_details_fullscreen(
         &self,
         collection: &CollectionDetail,
     ) -> Result<(), AppError> {
-        use crossterm::terminal::{
-            EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode, size,
-        };
-        use std::io::{self, Write};
-
-        // RAII cleanup structures
-        struct RawModeCleanup;
-        impl Drop for RawModeCleanup {
-            fn drop(&mut self) {
-                let _ = disable_raw_mode();
-            }
-        }
-
-        struct ScreenCleanup;
-        impl Drop for ScreenCleanup {
-            fn drop(&mut self) {
-                let _ = execute!(io::stdout(), LeaveAlternateScreen);
-            }
-        }
-
-        // Full screen mode - RAW mode + Alternate Screen
-        match enable_raw_mode() {
+        match terminal::enable_raw_mode() {
             Ok(()) => {
                 let _cleanup = RawModeCleanup;
                 execute!(io::stdout(), EnterAlternateScreen).ok();
                 let _screen_cleanup = ScreenCleanup;
 
-                // Get terminal size for dynamic width calculation
-                let (terminal_width, _terminal_height) = size().unwrap_or((80, 24));
+                let (terminal_width, _) = terminal::size().unwrap_or((80, 24));
+                let available_width = (terminal_width as usize).saturating_sub(5);
+                let field_w = (available_width * 30 / 100).clamp(8, 15);
+                let value_w = available_width.saturating_sub(field_w);
 
-                // Calculate appropriate column widths based on terminal size
-                let total_width = terminal_width as usize;
-                let border_width = 4; // "│ " + " │"
-                let separator_width = 1; // "│"
-                let available_width = total_width.saturating_sub(border_width + separator_width);
-
-                // Distribute width: 30% for field name, 70% for value
-                let field_width = (available_width * 30 / 100).clamp(8, 15);
-                let value_width = available_width.saturating_sub(field_width);
+                let top = format!("┌{:─<fw$}┬{:─<vw$}┐", "", "", fw = field_w, vw = value_w);
+                let bottom = format!("└{:─<fw$}┴{:─<vw$}┘", "", "", fw = field_w, vw = value_w);
 
                 loop {
-                    // Clear screen and reset cursor
                     execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).ok();
-
-                    // Header with colored title
                     execute!(
                         io::stdout(),
                         SetForegroundColor(Color::Cyan),
@@ -1425,91 +938,52 @@ impl InteractiveDisplay {
                         SetForegroundColor(Color::Yellow),
                         Print(format!(
                             "ID: {} | Name: {}",
-                            collection
-                                .id
-                                .map_or("root".to_string(), |id| id.to_string()),
+                            collection.id.map_or("root".into(), |id| id.to_string()),
                             collection.name
                         )),
                         ResetColor,
-                        Print("\r\n\r\n")
+                        Print("\r\n\r\n"),
+                        Print(&top),
+                        Print("\r\n")
                     )
                     .ok();
 
-                    // Dynamic table borders
-                    let top_border = format!(
-                        "┌{:─<width$}┬{:─<vwidth$}┐",
-                        "",
-                        "",
-                        width = field_width,
-                        vwidth = value_width
-                    );
-                    let _separator = format!(
-                        "├{:─<width$}┼{:─<vwidth$}┤",
-                        "",
-                        "",
-                        width = field_width,
-                        vwidth = value_width
-                    );
-                    let bottom_border = format!(
-                        "└{:─<width$}┴{:─<vwidth$}┘",
-                        "",
-                        "",
-                        width = field_width,
-                        vwidth = value_width
-                    );
-
-                    execute!(io::stdout(), Print(&top_border), Print("\r\n")).ok();
-
-                    // Display fields using execute for consistency
-                    let id_str = if let Some(id) = collection.id {
-                        format!("{}", id)
-                    } else {
-                        "root".to_string()
-                    };
-
-                    // Helper closure to print table row
-                    let print_row = |field: &str, value: &str| {
-                        let truncated_field = truncate_text(field, field_width);
-                        let truncated_value = truncate_text(value, value_width);
+                    let print_row = |f: &str, v: &str| {
                         execute!(
                             io::stdout(),
                             Print(format!(
-                                "│{:width$}│{:vwidth$}│\r\n",
-                                truncated_field,
-                                truncated_value,
-                                width = field_width,
-                                vwidth = value_width
+                                "│{:fw$}│{:vw$}│\r\n",
+                                truncate_text(f, field_w),
+                                truncate_text(v, value_w),
+                                fw = field_w,
+                                vw = value_w
                             ))
                         )
                         .ok();
                     };
 
-                    print_row("ID", &id_str);
+                    print_row(
+                        "ID",
+                        &collection.id.map_or("root".into(), |id| id.to_string()),
+                    );
                     print_row("Name", &collection.name);
-
-                    if let Some(description) = &collection.description {
-                        print_row("Description", description);
+                    if let Some(d) = &collection.description {
+                        print_row("Description", d);
+                    }
+                    if let Some(c) = &collection.color {
+                        print_row("Color", c);
+                    }
+                    if let Some(p) = collection.parent_id {
+                        print_row("Parent ID", &p.to_string());
+                    }
+                    if let Some(c) = &collection.created_at {
+                        print_row("Created", c);
+                    }
+                    if let Some(u) = &collection.updated_at {
+                        print_row("Updated", u);
                     }
 
-                    if let Some(color) = &collection.color {
-                        print_row("Color", color);
-                    }
-
-                    if let Some(parent_id) = collection.parent_id {
-                        print_row("Parent ID", &parent_id.to_string());
-                    }
-
-                    if let Some(created_at) = &collection.created_at {
-                        print_row("Created", created_at);
-                    }
-
-                    if let Some(updated_at) = &collection.updated_at {
-                        print_row("Updated", updated_at);
-                    }
-
-                    execute!(io::stdout(), Print(&bottom_border), Print("\r\n\r\n")).ok();
-
-                    // Control instructions
+                    execute!(io::stdout(), Print(&bottom), Print("\r\n\r\n")).ok();
                     execute!(
                         io::stdout(),
                         SetForegroundColor(Color::Green),
@@ -1517,105 +991,66 @@ impl InteractiveDisplay {
                         ResetColor
                     )
                     .ok();
-
                     io::stdout().flush().ok();
 
-                    // Handle input
-                    if let Event::Key(KeyEvent { code, kind, .. }) =
-                        event::read().unwrap_or(Event::Key(KeyEvent::from(KeyCode::Char('q'))))
+                    if let Ok(Event::Key(KeyEvent {
+                        code,
+                        kind: KeyEventKind::Press,
+                        modifiers,
+                        ..
+                    })) = event::read()
                     {
-                        if kind == KeyEventKind::Press {
-                            match code {
-                                KeyCode::Char('q') | KeyCode::Esc => break,
-                                KeyCode::Char('h') => {
-                                    self.show_collection_details_help().await?;
-                                }
-                                _ => {} // Ignore other keys
+                        match parse_key_event(code, modifiers) {
+                            KeyAction::Quit => break,
+                            KeyAction::Help => {
+                                self.show_simple_help(
+                                    "Collection Details - Help",
+                                    "Detailed info about this collection.",
+                                )
+                                .await?
                             }
+                            _ => {}
                         }
                     }
                 }
             }
             Err(_) => {
-                // Fallback: Simple output if RAW mode fails
                 println!("Collection Details:");
                 println!(
                     "ID: {}",
-                    collection
-                        .id
-                        .map_or("root".to_string(), |id| id.to_string())
+                    collection.id.map_or("root".into(), |id| id.to_string())
                 );
                 println!("Name: {}", collection.name);
-
-                if let Some(description) = &collection.description {
-                    println!("Description: {}", description);
+                if let Some(d) = &collection.description {
+                    println!("Description: {}", d);
                 }
-
-                if let Some(color) = &collection.color {
-                    println!("Color: {}", color);
+                if let Some(c) = &collection.color {
+                    println!("Color: {}", c);
                 }
-
-                if let Some(parent_id) = collection.parent_id {
-                    println!("Parent ID: {}", parent_id);
+                if let Some(p) = collection.parent_id {
+                    println!("Parent ID: {}", p);
                 }
-
-                if let Some(created_at) = &collection.created_at {
-                    println!("Created: {}", created_at);
+                if let Some(c) = &collection.created_at {
+                    println!("Created: {}", c);
                 }
-
-                if let Some(updated_at) = &collection.updated_at {
-                    println!("Updated: {}", updated_at);
+                if let Some(u) = &collection.updated_at {
+                    println!("Updated: {}", u);
                 }
             }
         }
-
         Ok(())
     }
 
-    /// Help display for collection details
-    async fn show_collection_details_help(&self) -> Result<(), AppError> {
-        execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).ok();
-
-        execute!(
-            io::stdout(),
-            SetForegroundColor(Color::Cyan),
-            Print("Collection Details - Help"),
-            ResetColor,
-            Print("\r\n\r\n"),
-            Print("Available Commands:\r\n"),
-            Print("  q - Quit and return to previous screen\r\n"),
-            Print("  h - Show this help\r\n"),
-            Print("  ESC - Same as 'q'\r\n"),
-            Print("\r\n"),
-            Print("This screen shows detailed information about a Metabase collection.\r\n"),
-            Print("Collections are used to organize questions and dashboards.\r\n"),
-            Print("\r\n"),
-            SetForegroundColor(Color::Yellow),
-            Print("Press any key to return..."),
-            ResetColor
-        )
-        .ok();
-
-        io::stdout().flush().ok();
-        event::read().ok(); // Wait for any key press
-
-        Ok(())
-    }
-
-    /// Display collection statistics interactively
     pub async fn display_collection_stats_interactive(
         &self,
         stats: &CollectionStats,
         collection_id: u32,
     ) -> Result<(), AppError> {
-        // Try to enable RAW mode for full-screen display
         match terminal::enable_raw_mode() {
             Ok(_) => {
+                let _cleanup = RawModeCleanup;
                 loop {
-                    // Clear screen and reset cursor
                     execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).ok();
-
-                    // Print statistics
                     println!(
                         "Collection Statistics (ID: {}) | [q]uit | [h]elp",
                         collection_id
@@ -1626,19 +1061,13 @@ impl InteractiveDisplay {
                     println!("│ Total Items      │ {:59} │", stats.item_count);
                     println!("│ Questions        │ {:59} │", stats.question_count);
                     println!("│ Dashboards       │ {:59} │", stats.dashboard_count);
-
-                    if let Some(last_updated) = &stats.last_updated {
-                        println!(
-                            "│ Last Updated     │ {:59} │",
-                            truncate_text(last_updated, 59)
-                        );
+                    if let Some(u) = &stats.last_updated {
+                        println!("│ Last Updated     │ {:59} │", truncate_text(u, 59));
                     }
-
                     println!(
                         "└──────────────────┴─────────────────────────────────────────────────────────────┘"
                     );
 
-                    // Control instructions with color (similar to query results)
                     execute!(
                         io::stdout(),
                         SetForegroundColor(Color::Green),
@@ -1646,38 +1075,70 @@ impl InteractiveDisplay {
                         ResetColor
                     )
                     .ok();
-
                     io::stdout().flush().ok();
 
-                    // Handle input
-                    if let Event::Key(KeyEvent { code, kind, .. }) =
-                        event::read().unwrap_or(Event::Key(KeyEvent::from(KeyCode::Char('q'))))
+                    if let Ok(Event::Key(KeyEvent {
+                        code,
+                        kind: KeyEventKind::Press,
+                        modifiers,
+                        ..
+                    })) = event::read()
                     {
-                        if kind == KeyEventKind::Press {
-                            match code {
-                                KeyCode::Char('q') | KeyCode::Esc => break,
-                                KeyCode::Char('h') => {
-                                    self.show_collection_details_help().await?;
-                                }
-                                _ => {} // Ignore other keys
+                        match parse_key_event(code, modifiers) {
+                            KeyAction::Quit => break,
+                            KeyAction::Help => {
+                                self.show_simple_help(
+                                    "Collection Stats - Help",
+                                    "Statistics for this collection.",
+                                )
+                                .await?
                             }
+                            _ => {}
                         }
                     }
                 }
             }
             Err(_) => {
-                // Fallback when RAW mode fails
                 println!("Warning: Could not enable full-screen mode, falling back to simple mode");
                 println!("Collection Statistics (ID: {}):", collection_id);
                 println!("  Total Items: {}", stats.item_count);
                 println!("  Questions: {}", stats.question_count);
                 println!("  Dashboards: {}", stats.dashboard_count);
-                if let Some(last_updated) = &stats.last_updated {
-                    println!("  Last Updated: {}", last_updated);
+                if let Some(u) = &stats.last_updated {
+                    println!("  Last Updated: {}", u);
                 }
             }
         }
+        Ok(())
+    }
 
+    async fn show_simple_help(&self, title: &str, extra: &str) -> Result<(), AppError> {
+        execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).ok();
+        execute!(
+            io::stdout(),
+            SetForegroundColor(Color::Cyan),
+            Print(title),
+            ResetColor,
+            Print("\r\n\r\n"),
+            Print("Commands:\r\n"),
+            Print("  q/ESC - Quit\r\n"),
+            Print("  n     - Next page\r\n"),
+            Print("  p     - Previous page\r\n"),
+            Print("  j/↓   - Scroll down\r\n"),
+            Print("  k/↑   - Scroll up\r\n"),
+            Print("  Home  - First page\r\n"),
+            Print("  End   - Last page\r\n"),
+            Print("  h     - Show this help\r\n"),
+            Print("\r\n"),
+            Print(extra),
+            Print("\r\n\r\n"),
+            SetForegroundColor(Color::Yellow),
+            Print("Press any key to return..."),
+            ResetColor
+        )
+        .ok();
+        io::stdout().flush().ok();
+        event::read().ok();
         Ok(())
     }
 }

--- a/src/core/services/dashboard_service.rs
+++ b/src/core/services/dashboard_service.rs
@@ -13,13 +13,13 @@ impl DashboardService {
 
     pub async fn list(&self, params: ListParams) -> Result<Vec<Dashboard>, ServiceError> {
         // Validate parameters
-        if let Some(limit) = params.limit {
-            if limit == 0 {
-                return Err(ServiceError::Validation {
-                    field: "limit".to_string(),
-                    message: "Limit must be greater than 0".to_string(),
-                });
-            }
+        if let Some(limit) = params.limit
+            && limit == 0
+        {
+            return Err(ServiceError::Validation {
+                field: "limit".to_string(),
+                message: "Limit must be greater than 0".to_string(),
+            });
         }
 
         // Call API client

--- a/src/display/display_options.rs
+++ b/src/display/display_options.rs
@@ -125,12 +125,12 @@ impl DisplayOptions {
             ));
         }
 
-        if let Some(offset) = self.offset {
-            if offset == usize::MAX {
-                return Err(AppError::Display(crate::error::DisplayError::Pagination(
-                    "Invalid offset value".to_string(),
-                )));
-            }
+        if let Some(offset) = self.offset
+            && offset == usize::MAX
+        {
+            return Err(AppError::Display(crate::error::DisplayError::Pagination(
+                "Invalid offset value".to_string(),
+            )));
         }
 
         Ok(())

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -20,72 +20,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_display_module_only_contains_ui_components() {
-        // This test ensures display module only exports UI components
-        // It should not re-export utilities from utils module
-
-        // Test that core UI components are available
-        let _pagination_manager = PaginationManager::new(10, 100, 0, DisplayMode::Paginated);
-        let _table_display = TableDisplay::new();
-        let _progress_tracker = ProgressTracker::new(vec!["step1".to_string()]);
-        let _display_options = DisplayOptions::default();
-
-        // This test will fail if utils re-exports are still present
-        // We should not be able to access MemoryEstimator or OffsetManager from display module
+    fn test_display_module_exports() {
+        let _ = PaginationManager::new(10, 100, 0, DisplayMode::Paginated);
+        let _ = TableDisplay::new();
+        let _ = ProgressTracker::new(vec!["step1".to_string()]);
+        let _ = DisplayOptions::default();
     }
 
     #[test]
-    fn test_display_module_ui_focus() {
-        // Verify that display module focuses on UI rendering only
-        // All modules should be related to presentation/visualization
-
-        // These should all be UI-related components
-        assert!(std::any::type_name::<TableDisplay>().contains("TableDisplay"));
-        assert!(std::any::type_name::<PaginationManager>().contains("PaginationManager"));
-        assert!(std::any::type_name::<ProgressTracker>().contains("ProgressTracker"));
-        assert!(std::any::type_name::<DisplayOptions>().contains("DisplayOptions"));
-    }
-
-    #[test]
-    fn test_display_can_use_utils_dependencies() {
-        // Test that display module can properly access utils functionality
-        // This ensures proper dependency direction: Display → Utils
-
-        // Test data utilities access - this is the main utils dependency for display
-        use crate::utils::data::OffsetManager;
-        let offset_manager = OffsetManager::new(Some(10)).expect("Should create OffsetManager");
-        assert!(!offset_manager.is_no_offset());
-
-        // Test that we can access OffsetManager with None
-        let no_offset_manager = OffsetManager::new(None).expect("Should create OffsetManager");
-        assert!(no_offset_manager.is_no_offset());
-
-        // This test passes if display can use utils without circular dependency
-    }
-
-    #[test]
-    fn test_no_circular_dependencies() {
-        // Ensure no circular dependencies exist
-        // utils should NOT import from display
-        // This test verifies the architectural constraint
-
-        // If this compiles and runs, it means:
-        // 1. Display can import from Utils (correct direction)
-        // 2. No circular dependency exists (compilation would fail)
-        // 3. Architecture layer dependency is preserved: CLI → Core → Storage → Utils
-
+    fn test_utils_dependency_direction() {
         use crate::utils::data::OffsetManager;
         use crate::utils::validation::validate_url;
 
-        // Test that utils functions are accessible from display
-        let _offset = OffsetManager::new(None).expect("Should create OffsetManager");
-        let _url_validation = validate_url("https://example.com");
-
-        // Test that we can access both data and validation utils
+        assert!(!OffsetManager::new(Some(10)).is_no_offset());
+        assert!(OffsetManager::new(None).is_no_offset());
         assert!(validate_url("https://example.com").is_ok());
         assert!(validate_url("invalid-url").is_err());
-
-        // Successful compilation means proper dependency direction
-        // Test validates that display can use utils without circular dependency
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,10 +75,6 @@ pub enum StorageError {
         path: String,
         source: std::io::Error,
     },
-    #[error("Session storage failed")]
-    SessionStorageFailed,
-    #[error("Configuration save failed")]
-    ConfigSaveFailed,
     #[error("Configuration parse error: {message}")]
     ConfigParseError { message: String },
     #[error("Configuration directory not found")]
@@ -135,12 +131,8 @@ pub enum ServiceError {
 pub enum UtilsError {
     #[error("Validation error: {message}")]
     Validation { message: String },
-    #[error("Memory calculation error: {message}")]
-    Memory { message: String },
     #[error("Data processing error: {message}")]
     DataProcessing { message: String },
-    #[error("Input processing error: {message}")]
-    InputProcessing { message: String },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -224,326 +216,180 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_cli_error_display() {
-        let cli_err = CliError::InvalidArguments("invalid arguments".to_string());
-        assert_eq!(
-            format!("{}", cli_err),
-            "Invalid arguments: invalid arguments"
+    fn test_error_display_formats() {
+        assert!(format!("{}", CliError::InvalidArguments("test".into())).contains("test"));
+        assert!(
+            format!(
+                "{}",
+                ApiError::Timeout {
+                    timeout_secs: 10,
+                    endpoint: "ep".into()
+                }
+            )
+            .contains("10")
         );
-        let cli_err = CliError::AuthRequired {
-            message: "message".to_string(),
-            hint: "hint".to_string(),
-            available_profiles: vec!["profile1".to_string(), "profile2".to_string()],
-        };
-        assert!(matches!(cli_err, CliError::AuthRequired { .. }));
-        if let CliError::AuthRequired {
-            message,
-            hint,
-            available_profiles,
-        } = cli_err
-        {
-            assert_eq!(message, "message");
-            assert_eq!(hint, "hint");
-            assert_eq!(
-                available_profiles,
-                vec!["profile1".to_string(), "profile2".to_string()]
-            );
-        }
-    }
-
-    #[test]
-    fn test_config_error_display() {
-        let config_err = ConfigError::FileNotFound {
-            path: "config.toml".to_string(),
-            hint: "hint".to_string(),
-        };
-        assert!(matches!(config_err, ConfigError::FileNotFound { .. }));
-        if let ConfigError::FileNotFound { path, hint } = config_err {
-            assert_eq!(path, "config.toml");
-            assert_eq!(hint, "hint");
-        };
-
-        let config_err = ConfigError::MissingField {
-            field: "field".to_string(),
-            field_type: "type".to_string(),
-        };
-        assert!(matches!(config_err, ConfigError::MissingField { .. }));
-        if let ConfigError::MissingField { field, field_type } = config_err {
-            assert_eq!(field, "field");
-            assert_eq!(field_type, "type");
-        };
-
-        let config_err = ConfigError::InvalidValue {
-            field: "field".to_string(),
-            value: "value".to_string(),
-            reason: "reason".to_string(),
-        };
-        assert!(matches!(config_err, ConfigError::InvalidValue { .. }));
-        if let ConfigError::InvalidValue {
-            field,
-            value,
-            reason,
-        } = config_err
-        {
-            assert_eq!(field, "field");
-            assert_eq!(value, "value");
-            assert_eq!(reason, "reason");
-        }
-    }
-
-    #[test]
-    fn test_api_error_display() {
-        let api_err = ApiError::Unauthorized {
-            status: 401,
-            endpoint: "endpoint".to_string(),
-            server_message: "message".to_string(),
-        };
-        assert!(matches!(api_err, ApiError::Unauthorized { .. }));
-        if let ApiError::Unauthorized {
-            status,
-            endpoint,
-            server_message,
-        } = api_err
-        {
-            assert_eq!(status, 401);
-            assert_eq!(endpoint, "endpoint");
-            assert_eq!(server_message, "message");
-        };
-
-        let api_err = ApiError::Timeout {
-            timeout_secs: 10,
-            endpoint: "endpoint".to_string(),
-        };
-        assert!(matches!(api_err, ApiError::Timeout { .. }));
-        if let ApiError::Timeout {
-            timeout_secs,
-            endpoint,
-        } = api_err
-        {
-            assert_eq!(timeout_secs, 10);
-            assert_eq!(endpoint, "endpoint");
-        };
-
-        let api_err = ApiError::Http {
-            status: 400,
-            endpoint: "endpoint".to_string(),
-            message: "message".to_string(),
-        };
-        assert!(matches!(api_err, ApiError::Http { .. }));
-        if let ApiError::Http {
-            status,
-            endpoint,
-            message,
-        } = api_err
-        {
-            assert_eq!(status, 400);
-            assert_eq!(endpoint, "endpoint");
-            assert_eq!(message, "message");
-        }
-    }
-
-    #[test]
-    fn test_app_error_display_cli() {
-        let app_err = AppError::Cli(CliError::InvalidArguments("invalid arguments".to_string()));
-        assert_eq!(
-            format!("{}", app_err),
-            "CliError: Invalid arguments: invalid arguments"
+        assert!(
+            format!(
+                "{}",
+                ConfigError::FileNotFound {
+                    path: "p".into(),
+                    hint: "h".into()
+                }
+            )
+            .contains("p")
         );
-        let app_err = AppError::Cli(CliError::AuthRequired {
-            message: "message".to_string(),
-            hint: "hint".to_string(),
-            available_profiles: vec!["profile1".to_string(), "profile2".to_string()],
-        });
-        assert!(matches!(
-            app_err,
-            AppError::Cli(CliError::AuthRequired { .. })
-        ));
-        if let AppError::Cli(CliError::AuthRequired {
-            message,
-            hint,
-            available_profiles,
-        }) = app_err
-        {
-            assert_eq!(message, "message");
-            assert_eq!(hint, "hint");
-            assert_eq!(
-                available_profiles,
-                vec!["profile1".to_string(), "profile2".to_string()]
-            );
-        }
+        assert!(
+            format!(
+                "{}",
+                ServiceError::AuthService {
+                    message: "m".into()
+                }
+            )
+            .contains("m")
+        );
+        assert!(
+            format!(
+                "{}",
+                UtilsError::Validation {
+                    message: "v".into()
+                }
+            )
+            .contains("v")
+        );
     }
 
     #[test]
-    fn test_app_error_display_api() {
-        let app_err = AppError::Api(ApiError::Unauthorized {
-            status: 401,
-            endpoint: "endpoint".to_string(),
-            server_message: "message".to_string(),
-        });
+    fn test_error_variants_constructible() {
         assert!(matches!(
-            app_err,
-            AppError::Api(ApiError::Unauthorized { .. })
+            CliError::AuthRequired {
+                message: "".into(),
+                hint: "".into(),
+                available_profiles: vec![]
+            },
+            CliError::AuthRequired { .. }
         ));
-        if let AppError::Api(ApiError::Unauthorized {
-            status,
-            endpoint,
-            server_message,
-        }) = app_err
-        {
-            assert_eq!(status, 401);
-            assert_eq!(endpoint, "endpoint");
-            assert_eq!(server_message, "message");
-        }
-
-        let app_err = AppError::Api(ApiError::Http {
-            status: 400,
-            endpoint: "endpoint".to_string(),
-            message: "message".to_string(),
-        });
-        assert!(matches!(app_err, AppError::Api(ApiError::Http { .. })));
-        if let AppError::Api(ApiError::Http {
-            status,
-            endpoint,
-            message,
-        }) = app_err
-        {
-            assert_eq!(status, 400);
-            assert_eq!(endpoint, "endpoint");
-            assert_eq!(message, "message");
-        }
-
-        let app_err = AppError::Api(ApiError::Timeout {
-            timeout_secs: 10,
-            endpoint: "endpoint".to_string(),
-        });
-        assert!(matches!(app_err, AppError::Api(ApiError::Timeout { .. })));
-        if let AppError::Api(ApiError::Timeout {
-            timeout_secs,
-            endpoint,
-        }) = app_err
-        {
-            assert_eq!(timeout_secs, 10);
-            assert_eq!(endpoint, "endpoint");
-        }
+        assert!(matches!(
+            ApiError::Unauthorized {
+                status: 401,
+                endpoint: "".into(),
+                server_message: "".into()
+            },
+            ApiError::Unauthorized { .. }
+        ));
+        assert!(matches!(
+            ApiError::Http {
+                status: 400,
+                endpoint: "".into(),
+                message: "".into()
+            },
+            ApiError::Http { .. }
+        ));
+        assert!(matches!(
+            ConfigError::MissingField {
+                field: "".into(),
+                field_type: "".into()
+            },
+            ConfigError::MissingField { .. }
+        ));
+        assert!(matches!(
+            ConfigError::InvalidValue {
+                field: "".into(),
+                value: "".into(),
+                reason: "".into()
+            },
+            ConfigError::InvalidValue { .. }
+        ));
     }
 
     #[test]
-    fn test_app_error_display_config() {
-        if let AppError::Config(ConfigError::FileNotFound { path, hint }) =
+    fn test_app_error_severity() {
+        assert_eq!(
+            AppError::Api(ApiError::Unauthorized {
+                status: 401,
+                endpoint: "".into(),
+                server_message: "".into()
+            })
+            .severity(),
+            ErrorSeverity::High
+        );
+        assert_eq!(
+            AppError::Api(ApiError::Http {
+                status: 500,
+                endpoint: "".into(),
+                message: "".into()
+            })
+            .severity(),
+            ErrorSeverity::High
+        );
+        assert_eq!(
+            AppError::Api(ApiError::Http {
+                status: 400,
+                endpoint: "".into(),
+                message: "".into()
+            })
+            .severity(),
+            ErrorSeverity::Medium
+        );
+        assert_eq!(
             AppError::Config(ConfigError::FileNotFound {
-                path: "config.toml".to_string(),
-                hint: "hint".to_string(),
+                path: "".into(),
+                hint: "".into()
             })
-        {
-            assert_eq!(path, "config.toml");
-            assert_eq!(hint, "hint");
-        };
+            .severity(),
+            ErrorSeverity::High
+        );
+        assert_eq!(
+            AppError::Display(DisplayError::Pagination("".into())).severity(),
+            ErrorSeverity::Low
+        );
+        assert_eq!(
+            AppError::Service(ServiceError::AuthService { message: "".into() }).severity(),
+            ErrorSeverity::High
+        );
+    }
 
-        if let AppError::Config(ConfigError::MissingField { field, field_type }) =
-            AppError::Config(ConfigError::MissingField {
-                field: "field".to_string(),
-                field_type: "type".to_string(),
-            })
-        {
-            assert_eq!(field, "field");
-            assert_eq!(field_type, "type");
-        };
-
-        if let AppError::Config(ConfigError::InvalidValue {
-            field,
-            value,
-            reason,
-        }) = AppError::Config(ConfigError::InvalidValue {
-            field: "field".to_string(),
-            value: "value".to_string(),
-            reason: "reason".to_string(),
-        }) {
-            assert_eq!(field, "field");
-            assert_eq!(value, "value");
-            assert_eq!(reason, "reason");
+    #[test]
+    fn test_app_error_conversion() {
+        let cli: AppError = CliError::InvalidArguments("".into()).into();
+        let api: AppError = ApiError::Timeout {
+            timeout_secs: 1,
+            endpoint: "".into(),
         }
+        .into();
+        let config: AppError = ConfigError::FileNotFound {
+            path: "".into(),
+            hint: "".into(),
+        }
+        .into();
+        assert!(matches!(cli, AppError::Cli(_)));
+        assert!(matches!(api, AppError::Api(_)));
+        assert!(matches!(config, AppError::Config(_)));
     }
 
     #[test]
-    fn test_service_error_display() {
-        let service_err = ServiceError::AuthService {
-            message: "Authentication failed".to_string(),
-        };
-        assert_eq!(
-            format!("{}", service_err),
-            "Authentication service error: Authentication failed"
+    fn test_troubleshooting_hints() {
+        assert!(
+            AppError::Auth(AuthError::InvalidCredentials)
+                .troubleshooting_hint()
+                .is_some()
         );
-
-        let service_err = ServiceError::ConfigService {
-            message: "Configuration invalid".to_string(),
-        };
-        assert_eq!(
-            format!("{}", service_err),
-            "Configuration service error: Configuration invalid"
+        assert!(
+            AppError::Api(ApiError::Timeout {
+                timeout_secs: 1,
+                endpoint: "".into()
+            })
+            .troubleshooting_hint()
+            .is_some()
         );
-
-        let service_err = ServiceError::QuestionService {
-            message: "Question execution failed".to_string(),
-        };
-        assert_eq!(
-            format!("{}", service_err),
-            "Question service error: Question execution failed"
+        assert!(
+            AppError::Question(QuestionError::NotFound { id: 1 })
+                .troubleshooting_hint()
+                .is_some()
         );
-    }
-
-    #[test]
-    fn test_utils_error_display() {
-        let utils_err = UtilsError::Validation {
-            message: "Invalid URL format".to_string(),
-        };
-        assert_eq!(
-            format!("{}", utils_err),
-            "Validation error: Invalid URL format"
-        );
-
-        let utils_err = UtilsError::Memory {
-            message: "Memory allocation failed".to_string(),
-        };
-        assert_eq!(
-            format!("{}", utils_err),
-            "Memory calculation error: Memory allocation failed"
-        );
-
-        let utils_err = UtilsError::DataProcessing {
-            message: "Data parsing failed".to_string(),
-        };
-        assert_eq!(
-            format!("{}", utils_err),
-            "Data processing error: Data parsing failed"
-        );
-
-        let utils_err = UtilsError::InputProcessing {
-            message: "Input validation failed".to_string(),
-        };
-        assert_eq!(
-            format!("{}", utils_err),
-            "Input processing error: Input validation failed"
-        );
-    }
-
-    #[test]
-    fn test_app_error_service_utils_integration() {
-        let app_err = AppError::Service(ServiceError::AuthService {
-            message: "Authentication failed".to_string(),
-        });
-        assert_eq!(app_err.severity(), ErrorSeverity::High);
-        assert_eq!(
-            format!("{}", app_err),
-            "ServiceError: Authentication service error: Authentication failed"
-        );
-
-        let app_err = AppError::Utils(UtilsError::Validation {
-            message: "Invalid input".to_string(),
-        });
-        assert_eq!(app_err.severity(), ErrorSeverity::Low);
-        assert_eq!(
-            format!("{}", app_err),
-            "UtilsError: Validation error: Invalid input"
+        assert!(
+            AppError::Display(DisplayError::Pagination("".into()))
+                .troubleshooting_hint()
+                .is_none()
         );
     }
 }

--- a/src/utils/data.rs
+++ b/src/utils/data.rs
@@ -1,130 +1,69 @@
-// Start position specification functionality using --offset option
-
 use crate::api::models::{QueryData, QueryResult};
 use crate::error::AppError;
 
-/// Struct to manage offset functionality
-///
-/// Provides functionality to display from the start position specified by --offset option.
-/// When used in combination with pagination, it enables display from arbitrary positions in large datasets.
+/// Manages offset for --offset option pagination
 #[derive(Debug, Clone)]
 pub struct OffsetManager {
-    /// Start position (0-based)
     pub offset: usize,
 }
 
 impl OffsetManager {
-    /// Create new OffsetManager
-    ///
-    /// # Arguments
-    /// * `offset` - Start position (0-based, defaults to 0 if None)
-    ///
     /// # Examples
     /// ```
     /// use mbr_cli::utils::data::OffsetManager;
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let no_offset = OffsetManager::new(None)?;
-    /// let with_offset = OffsetManager::new(Some(10))?;
-    /// # Ok(())
-    /// # }
+    /// let manager = OffsetManager::new(Some(10));
+    /// assert_eq!(manager.offset, 10);
     /// ```
-    pub fn new(offset: Option<usize>) -> Result<Self, AppError> {
-        let offset = offset.unwrap_or(0);
-        Ok(OffsetManager { offset })
+    pub fn new(offset: Option<usize>) -> Self {
+        OffsetManager {
+            offset: offset.unwrap_or(0),
+        }
     }
 
-    /// Apply offset to QueryResult
-    ///
-    /// # Arguments
-    /// * `result` - Original QueryResult
-    ///
-    /// # Returns
-    /// New QueryResult starting from offset position
-    ///
-    /// # Errors
-    /// Returns error if offset is out of data range
-    ///
-    /// # Performance
-    /// Performs efficient slicing for large datasets
+    /// Apply offset to QueryResult, returning sliced data from offset position
     pub fn apply_offset(&self, result: &QueryResult) -> Result<QueryResult, AppError> {
         let total_rows = result.data.rows.len();
 
-        // Check if offset is out of range
         if self.offset > total_rows {
-            return Err(AppError::Display(crate::error::DisplayError::Pagination(
-                format!(
-                    "Offset {} is out of range (max: {})",
-                    self.offset, total_rows
-                ),
-            )));
+            return Err(Self::offset_error(self.offset, total_rows));
         }
 
-        // Optimization for offset 0 (avoid data copying)
-        if self.offset == 0 {
-            return Ok(QueryResult {
-                data: QueryData {
-                    cols: result.data.cols.clone(),
-                    rows: result.data.rows.clone(),
-                },
-            });
-        }
-
-        // Extract data from offset position (efficient slicing)
-        let offset_rows = if self.offset < total_rows {
+        let rows = if self.offset == 0 {
+            result.data.rows.clone()
+        } else if self.offset < total_rows {
             result.data.rows[self.offset..].to_vec()
         } else {
-            Vec::new() // Empty if offset is at end
+            Vec::new()
         };
 
         Ok(QueryResult {
             data: QueryData {
                 cols: result.data.cols.clone(),
-                rows: offset_rows,
+                rows,
             },
         })
     }
 
-    /// Validate if offset is valid
-    ///
-    /// # Arguments
-    /// * `total_records` - Total record count
-    ///
-    /// # Errors
-    /// Returns error if offset is out of range
     pub fn validate_offset(&self, total_records: usize) -> Result<(), AppError> {
         if self.offset > total_records {
-            return Err(AppError::Display(crate::error::DisplayError::Pagination(
-                format!(
-                    "Offset {} is out of range (max: {})",
-                    self.offset, total_records
-                ),
-            )));
+            return Err(Self::offset_error(self.offset, total_records));
         }
         Ok(())
     }
 
-    /// Check if no offset is set
-    ///
-    /// # Returns
-    /// true if offset is 0
     pub fn is_no_offset(&self) -> bool {
         self.offset == 0
     }
 
-    /// Calculate remaining record count
-    ///
-    /// # Arguments
-    /// * `total_records` - Total record count
-    ///
-    /// # Returns
-    /// Remaining record count from offset position
     pub fn remaining_records(&self, total_records: usize) -> usize {
-        if self.offset >= total_records {
-            0
-        } else {
-            total_records - self.offset
-        }
+        total_records.saturating_sub(self.offset)
+    }
+
+    fn offset_error(offset: usize, max: usize) -> AppError {
+        AppError::Display(crate::error::DisplayError::Pagination(format!(
+            "Offset {} is out of range (max: {})",
+            offset, max
+        )))
     }
 }
 
@@ -134,26 +73,25 @@ mod tests {
     use crate::api::models::Column;
     use serde_json::json;
 
-    // Test helper function
-    fn create_test_columns() -> Vec<Column> {
+    fn test_columns() -> Vec<Column> {
         vec![
             Column {
-                name: "id".to_string(),
-                display_name: "ID".to_string(),
-                base_type: "type/Integer".to_string(),
+                name: "id".into(),
+                display_name: "ID".into(),
+                base_type: "type/Integer".into(),
             },
             Column {
-                name: "name".to_string(),
-                display_name: "Name".to_string(),
-                base_type: "type/Text".to_string(),
+                name: "name".into(),
+                display_name: "Name".into(),
+                base_type: "type/Text".into(),
             },
         ]
     }
 
-    fn create_test_query_result() -> QueryResult {
+    fn test_query_result() -> QueryResult {
         QueryResult {
             data: QueryData {
-                cols: create_test_columns(),
+                cols: test_columns(),
                 rows: vec![
                     vec![json!(1), json!("Alice")],
                     vec![json!(2), json!("Bob")],
@@ -166,128 +104,53 @@ mod tests {
     }
 
     #[test]
-    fn test_offset_manager_new_with_none() {
-        // When None is passed, offset is 0
-        let manager = OffsetManager::new(None).unwrap();
-        assert_eq!(manager.offset, 0);
-        assert!(manager.is_no_offset());
-    }
-
-    #[test]
-    fn test_offset_manager_new_with_value() {
-        // When value is passed, use that value
-        let manager = OffsetManager::new(Some(10)).unwrap();
-        assert_eq!(manager.offset, 10);
-        assert!(!manager.is_no_offset());
-    }
-
-    #[test]
-    fn test_remaining_records_middle() {
-        // Remaining records from middle position
-        let manager = OffsetManager::new(Some(2)).unwrap();
-        let remaining = manager.remaining_records(5);
-        assert_eq!(remaining, 3);
-    }
-
-    #[test]
-    fn test_remaining_records_end() {
-        // Remaining records from end position
-        let manager = OffsetManager::new(Some(5)).unwrap();
-        let remaining = manager.remaining_records(5);
-        assert_eq!(remaining, 0);
-    }
-
-    #[test]
-    fn test_remaining_records_out_of_range() {
-        // Remaining records from out-of-range position
-        let manager = OffsetManager::new(Some(10)).unwrap();
-        let remaining = manager.remaining_records(5);
-        assert_eq!(remaining, 0);
+    fn test_new() {
+        assert_eq!(OffsetManager::new(None).offset, 0);
+        assert_eq!(OffsetManager::new(Some(10)).offset, 10);
     }
 
     #[test]
     fn test_is_no_offset() {
-        // No offset check
-        let manager_no_offset = OffsetManager::new(Some(0)).unwrap();
-        assert!(manager_no_offset.is_no_offset());
-
-        let manager_with_offset = OffsetManager::new(Some(1)).unwrap();
-        assert!(!manager_with_offset.is_no_offset());
+        assert!(OffsetManager::new(Some(0)).is_no_offset());
+        assert!(!OffsetManager::new(Some(1)).is_no_offset());
     }
 
     #[test]
-    fn test_apply_offset_no_offset() {
-        // For offset 0, return all data
-        let manager = OffsetManager::new(Some(0)).unwrap();
-        let original = create_test_query_result();
+    fn test_remaining_records() {
+        assert_eq!(OffsetManager::new(Some(2)).remaining_records(5), 3);
+        assert_eq!(OffsetManager::new(Some(5)).remaining_records(5), 0);
+        assert_eq!(OffsetManager::new(Some(10)).remaining_records(5), 0);
+    }
 
-        let result = manager.apply_offset(&original).unwrap();
+    #[test]
+    fn test_apply_offset() {
+        let original = test_query_result();
 
+        // offset 0: all data
+        let result = OffsetManager::new(Some(0)).apply_offset(&original).unwrap();
         assert_eq!(result.data.rows.len(), 5);
-        assert_eq!(result.data.rows[0][0], json!(1));
-        assert_eq!(result.data.rows[4][0], json!(5));
-    }
 
-    #[test]
-    fn test_apply_offset_middle_position() {
-        // For offset 2, from 3rd to last
-        let manager = OffsetManager::new(Some(2)).unwrap();
-        let original = create_test_query_result();
-
-        let result = manager.apply_offset(&original).unwrap();
-
+        // offset 2: from 3rd row
+        let result = OffsetManager::new(Some(2)).apply_offset(&original).unwrap();
         assert_eq!(result.data.rows.len(), 3);
-        assert_eq!(result.data.rows[0][0], json!(3)); // Charlie
-        assert_eq!(result.data.rows[2][0], json!(5)); // Eve
-    }
+        assert_eq!(result.data.rows[0][0], json!(3));
 
-    #[test]
-    fn test_apply_offset_last_position() {
-        // For offset at last position, empty data
-        let manager = OffsetManager::new(Some(5)).unwrap();
-        let original = create_test_query_result();
-
-        let result = manager.apply_offset(&original).unwrap();
-
+        // offset at end: empty
+        let result = OffsetManager::new(Some(5)).apply_offset(&original).unwrap();
         assert_eq!(result.data.rows.len(), 0);
-        assert_eq!(result.data.cols.len(), 2); // Column info is preserved
+        assert_eq!(result.data.cols.len(), 2);
+
+        // offset out of range: error
+        assert!(
+            OffsetManager::new(Some(10))
+                .apply_offset(&original)
+                .is_err()
+        );
     }
 
     #[test]
-    fn test_apply_offset_out_of_range() {
-        // For offset out of range, error
-        let manager = OffsetManager::new(Some(10)).unwrap();
-        let original = create_test_query_result();
-
-        let result = manager.apply_offset(&original);
-        assert!(result.is_err());
-
-        if let Err(AppError::Display(crate::error::DisplayError::Pagination(msg))) = result {
-            assert!(msg.contains("Offset 10 is out of range"));
-        } else {
-            panic!("Expected DisplayError::Pagination");
-        }
-    }
-
-    #[test]
-    fn test_validate_offset_valid() {
-        // Valid offset
-        let manager = OffsetManager::new(Some(3)).unwrap();
-        let result = manager.validate_offset(5);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_validate_offset_invalid() {
-        // Invalid offset
-        let manager = OffsetManager::new(Some(10)).unwrap();
-        let result = manager.validate_offset(5);
-        assert!(result.is_err());
-
-        if let Err(AppError::Display(crate::error::DisplayError::Pagination(msg))) = result {
-            assert!(msg.contains("Offset 10 is out of range"));
-        } else {
-            panic!("Expected DisplayError::Pagination");
-        }
+    fn test_validate_offset() {
+        assert!(OffsetManager::new(Some(3)).validate_offset(5).is_ok());
+        assert!(OffsetManager::new(Some(10)).validate_offset(5).is_err());
     }
 }


### PR DESCRIPTION
- interactive_display.rs: 1,677→935 lines (RAII統合, KeyAction enum)
- table.rs: 942→648 lines (ヘルパー追加, ColumnWidths構造体)
- error.rs, data.rs: 冗長コメント削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)