### PR TITLE
feat: add TUI foundation with workspace migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +167,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,7 +250,21 @@ checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
  "crossterm 0.28.1",
  "unicode-segmentation",
- "unicode-width 0.2.1",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -275,8 +310,11 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.9.1",
  "crossterm_winapi",
+ "mio",
  "parking_lot",
  "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
@@ -305,6 +343,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -370,6 +443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +484,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -522,6 +607,11 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -696,6 +786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +820,28 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -757,6 +875,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -856,6 +983,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "mbr-cli"
 version = "0.1.3"
 dependencies = [
@@ -888,6 +1024,16 @@ dependencies = [
  "tokio",
  "toml",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "mbr-tui"
+version = "0.1.0"
+dependencies = [
+ "crossterm 0.29.0",
+ "mbr-core",
+ "ratatui",
+ "tokio",
 ]
 
 [[package]]
@@ -1035,6 +1181,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1280,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.9.1",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1443,10 +1616,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -1699,6 +1900,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,9 +1918,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "url"

--- a/crates/mbr-tui/Cargo.toml
+++ b/crates/mbr-tui/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mbr-tui"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Terminal UI for Metabase API interaction"
+keywords = ["metabase", "tui", "terminal", "ratatui"]
+categories = ["command-line-utilities"]
+
+[[bin]]
+name = "mbr-tui"
+path = "src/main.rs"
+
+[dependencies]
+mbr-core = { path = "../mbr-core" }
+ratatui.workspace = true
+crossterm.workspace = true
+tokio.workspace = true

--- a/crates/mbr-tui/src/app.rs
+++ b/crates/mbr-tui/src/app.rs
@@ -1,0 +1,166 @@
+//! Application state and logic for the TUI.
+//!
+//! This module contains the core application state and the main run loop.
+
+use crossterm::event::{KeyCode, KeyModifiers};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+};
+
+use crate::event::{Event, EventHandler};
+
+/// ASCII art banner for mbr-tui
+const BANNER: &str = r#"
+                 _                  _           _
+  _ __ ___  | |__  _ __       | |_ _   _ (_)
+ | '_ ` _ \ | '_ \| '__|_____ | __| | | || |
+ | | | | | || |_) | |  |_____|| |_| |_| || |
+ |_| |_| |_||_.__/|_|         \__|\__,_||_|
+"#;
+
+/// The main application state.
+pub struct App {
+    /// Whether the application should quit
+    pub should_quit: bool,
+    /// Current status message
+    pub status: String,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl App {
+    /// Create a new application instance.
+    pub fn new() -> Self {
+        Self {
+            should_quit: false,
+            status: String::from("Welcome to mbr-tui! Press 'q' to quit."),
+        }
+    }
+
+    /// Run the main application loop.
+    pub fn run(
+        &mut self,
+        terminal: &mut ratatui::Terminal<impl ratatui::backend::Backend>,
+    ) -> std::io::Result<()> {
+        let event_handler = EventHandler::new(250);
+
+        while !self.should_quit {
+            // Draw the UI
+            terminal.draw(|frame| self.draw(frame))?;
+
+            // Handle events
+            match event_handler.next()? {
+                Event::Key(key) => self.handle_key(key.code, key.modifiers),
+                Event::Resize(_, _) => {} // Terminal will redraw automatically
+                Event::Tick => {}         // Can be used for animations/updates
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handle keyboard input.
+    fn handle_key(&mut self, code: KeyCode, modifiers: KeyModifiers) {
+        match code {
+            KeyCode::Char('q') | KeyCode::Char('Q') => {
+                self.should_quit = true;
+            }
+            KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
+                self.should_quit = true;
+            }
+            KeyCode::Esc => {
+                self.should_quit = true;
+            }
+            _ => {}
+        }
+    }
+
+    /// Draw the UI.
+    fn draw(&self, frame: &mut Frame) {
+        let size = frame.area();
+
+        // Create layout with header, main content, and footer
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3), // Header
+                Constraint::Min(0),    // Main content
+                Constraint::Length(3), // Footer
+            ])
+            .split(size);
+
+        // Header
+        let header = Paragraph::new(Line::from(vec![
+            Span::styled(
+                " mbr-tui ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("- Metabase Terminal UI"),
+        ]))
+        .block(Block::default().borders(Borders::ALL));
+        frame.render_widget(header, chunks[0]);
+
+        // Main content area with banner
+        let mut lines: Vec<Line> = Vec::new();
+        lines.push(Line::from(""));
+
+        // Add banner with cyan color
+        for banner_line in BANNER.lines() {
+            lines.push(Line::from(Span::styled(
+                banner_line.to_string(),
+                Style::default().fg(Color::Cyan),
+            )));
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "  Metabase Terminal UI",
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(Span::styled(
+            "  Interactive interface for your data",
+            Style::default().fg(Color::DarkGray),
+        )));
+        lines.push(Line::from(""));
+        lines.push(Line::from(""));
+        lines.push(Line::from("  Features:"));
+        lines.push(Line::from(Span::styled(
+            "    ◆ Question browser",
+            Style::default().fg(Color::Yellow),
+        )));
+        lines.push(Line::from(Span::styled(
+            "    ◆ Query execution",
+            Style::default().fg(Color::Yellow),
+        )));
+        lines.push(Line::from(Span::styled(
+            "    ◆ Result visualization",
+            Style::default().fg(Color::Yellow),
+        )));
+
+        let main_content =
+            Paragraph::new(lines).block(Block::default().title(" Welcome ").borders(Borders::ALL));
+        frame.render_widget(main_content, chunks[1]);
+
+        // Footer with status and keybindings
+        let footer = Paragraph::new(Line::from(vec![
+            Span::styled(" q ", Style::default().fg(Color::Yellow)),
+            Span::raw("Quit  "),
+            Span::styled("│", Style::default().fg(Color::DarkGray)),
+            Span::raw(format!("  {}", self.status)),
+        ]))
+        .block(Block::default().borders(Borders::ALL));
+        frame.render_widget(footer, chunks[2]);
+    }
+}

--- a/crates/mbr-tui/src/event.rs
+++ b/crates/mbr-tui/src/event.rs
@@ -1,0 +1,47 @@
+//! Event handling for the TUI application.
+//!
+//! This module provides keyboard and terminal event handling using crossterm.
+
+use crossterm::event::{self, Event as CrosstermEvent, KeyEvent};
+use std::time::Duration;
+
+/// Terminal events that the application can handle.
+#[derive(Debug)]
+pub enum Event {
+    /// Keyboard input event
+    Key(KeyEvent),
+    /// Terminal tick for periodic updates
+    Tick,
+    /// Terminal resize event
+    Resize(u16, u16),
+}
+
+/// Event handler that polls for terminal events.
+pub struct EventHandler {
+    /// Tick rate for periodic updates (in milliseconds)
+    tick_rate: Duration,
+}
+
+impl EventHandler {
+    /// Create a new event handler with the specified tick rate.
+    pub fn new(tick_rate_ms: u64) -> Self {
+        Self {
+            tick_rate: Duration::from_millis(tick_rate_ms),
+        }
+    }
+
+    /// Poll for the next event.
+    ///
+    /// Returns `Some(Event)` if an event is available, `None` on timeout.
+    pub fn next(&self) -> std::io::Result<Event> {
+        if event::poll(self.tick_rate)? {
+            match event::read()? {
+                CrosstermEvent::Key(key) => Ok(Event::Key(key)),
+                CrosstermEvent::Resize(w, h) => Ok(Event::Resize(w, h)),
+                _ => Ok(Event::Tick),
+            }
+        } else {
+            Ok(Event::Tick)
+        }
+    }
+}

--- a/crates/mbr-tui/src/main.rs
+++ b/crates/mbr-tui/src/main.rs
@@ -1,0 +1,53 @@
+//! mbr-tui - Terminal UI for Metabase
+//!
+//! A terminal-based interface for interacting with Metabase,
+//! similar to lazygit, k9s, or htop.
+
+use crossterm::{
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::backend::CrosstermBackend;
+use std::io::{self, stdout};
+
+mod app;
+mod event;
+
+use app::App;
+
+fn main() -> std::io::Result<()> {
+    // Setup terminal
+    enable_raw_mode()?;
+    let mut stdout = stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = ratatui::Terminal::new(backend)?;
+
+    // Set panic hook to restore terminal on panic
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        let _ = restore_terminal();
+        original_hook(panic_info);
+    }));
+
+    // Create and run app
+    let mut app = App::new();
+    let result = app.run(&mut terminal);
+
+    // Cleanup terminal
+    restore_terminal()?;
+
+    // Report errors
+    if let Err(ref err) = result {
+        eprintln!("Application error: {:?}", err);
+    }
+
+    result
+}
+
+/// Restore terminal to normal state.
+fn restore_terminal() -> io::Result<()> {
+    disable_raw_mode()?;
+    execute!(io::stdout(), LeaveAlternateScreen)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Migrate to Cargo workspace structure with `mbr-core` and `mbr-cli` crates
- Add new `mbr-tui` crate with ratatui-based terminal UI foundation
- Aggressive code cleanup removing unused features (-2,741 lines net)

## Changes

### Workspace Migration
- **mbr-core**: Core library (API, services, storage, utils, display, error)
- **mbr-cli**: CLI binary with command handlers
- **mbr-tui**: New TUI binary with ratatui foundation

### TUI Foundation (Phase 1)
- Event loop with `draw → handle_event → repeat` pattern
- Panic hook for terminal state restoration
- ASCII art banner display
- Basic layout (header, content, footer)
- Keyboard handling (q/Q/Esc/Ctrl+C to quit)

### Code Quality
- Added `prelude` module for convenient imports
- Comprehensive doc comments with architecture diagram
- All 97 tests passing

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` - 97 tests pass
- [x] `cargo fmt --check` passes
- [x] `cargo run -p mbr-tui` starts TUI correctly
- [x] Panic hook tested - terminal restores on panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)